### PR TITLE
Fix DI import

### DIFF
--- a/src/api/versions/v1/services/scores-service.ts
+++ b/src/api/versions/v1/services/scores-service.ts
@@ -1,5 +1,4 @@
-import { inject } from "https://jsr.io/@needle-di/core/1.0.0/src/context.ts";
-import { injectable } from "https://jsr.io/@needle-di/core/1.0.0/src/decorators.ts";
+import { inject, injectable } from "@needle-di/core";
 import { CryptoService } from "../../../../core/services/crypto-service.ts";
 import { KVService } from "../../../../core/services/kv-service.ts";
 import { ScoreKV } from "../interfaces/kv/score.ts";


### PR DESCRIPTION
## Summary
- use package import for `@needle-di/core`
- revert stricter slot filtering logic

## Testing
- `deno task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2020f6148327bb230c56969d16cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated import sources for improved consistency. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->