### PR TITLE
Add online players broadcast

### DIFF
--- a/src/api/versions/v1/enums/websocket-enum.ts
+++ b/src/api/versions/v1/enums/websocket-enum.ts
@@ -2,4 +2,5 @@ export enum WebSocketType {
   Notification = 0,
   PlayerIdentity = 1,
   Tunnel = 2,
+  OnlinePlayers = 3,
 }

--- a/src/api/versions/v1/services/websocket-service.ts
+++ b/src/api/versions/v1/services/websocket-service.ts
@@ -85,6 +85,7 @@ export class WebSocketService {
 
     await this.kvService.setSession(userId, session);
     this.users.set(userToken, webSocketUser);
+    this.notifyOnlinePlayers();
   }
 
   private async handleDisconnection(user: WebSocketUser): Promise<void> {
@@ -100,6 +101,7 @@ export class WebSocketService {
     if (result.ok) {
       console.log(`Deleted temporary data for user ${userName}`);
       this.users.delete(userToken);
+      this.notifyOnlinePlayers();
     } else {
       console.error(`Failed to delete temporary data for user ${userName}`);
       user.setWebSocket(null);
@@ -175,6 +177,18 @@ export class WebSocketService {
         .bytes(textBytes)
         .toArrayBuffer();
 
+      this.sendMessage(user, payload);
+    }
+  }
+
+  private notifyOnlinePlayers(): void {
+    const total = this.getTotalSessions();
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebSocketType.OnlinePlayers)
+      .unsignedInt16(total)
+      .toArrayBuffer();
+
+    for (const user of this.users.values()) {
       this.sendMessage(user, payload);
     }
   }


### PR DESCRIPTION
## Summary
- add `OnlinePlayers` WebSocket type
- broadcast online players count to all connected users when players join or leave

## Testing
- `deno task check` *(fails: invalid peer certificate when fetching npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_686a5a037628832787ca4f079f1e544a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now receive real-time updates on the number of online players whenever someone connects or disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->