### PR TITLE
Add cross-instance player count sync

### DIFF
--- a/src/api/versions/v1/constants/websocket-constants.ts
+++ b/src/api/versions/v1/constants/websocket-constants.ts
@@ -1,1 +1,2 @@
 export const TUNNEL_CHANNEL = "tunnel_message";
+export const ONLINE_USERS_CHANNEL = "online_users";


### PR DESCRIPTION
## Summary
- support an optional `SERVER_ID` env variable
- broadcast online player counts via `online_users` channel
- track and sum counts from all server instances
- generate server ID randomly instead of using the environment
- remove self-message check and rely on broadcast events to trigger updates

## Testing
- `deno task check` *(fails: error sending request for url https://registry.npmjs.org/zod/-/zod-3.25.74.tgz: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_686aa984bac0832787f065901ec01275