### PR TITLE
Implement TTL cleanup for websocket server counts

### DIFF
--- a/src/api/versions/v1/constants/websocket-constants.ts
+++ b/src/api/versions/v1/constants/websocket-constants.ts
@@ -1,2 +1,5 @@
 export const TUNNEL_CHANNEL = "tunnel_message";
 export const ONLINE_USERS_CHANNEL = "online_users";
+// Amount of time in milliseconds to keep online users data from other servers
+// four hours in milliseconds
+export const ONLINE_USERS_SERVER_TTL = 4 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- add TTL constant for cleaning up remote server count entries
- track timestamp for server user counts
- periodically remove stale server entries
- set TTL duration to four hours

## Testing
- `deno fmt src/api/versions/v1/constants/websocket-constants.ts src/api/versions/v1/services/websocket-service.ts`
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_686aafe99d10832795e2497be48cc178