### PR TITLE
Implement high score notifications

### DIFF
--- a/src/api/versions/v1/constants/event-constants.ts
+++ b/src/api/versions/v1/constants/event-constants.ts
@@ -1,1 +1,2 @@
-export const NOTIFICATION_EVENT = "notification";
+export const GLOBAL_NOTIFICATION_EVENT = "global_notification";
+export const USER_NOTIFICATION_EVENT = "user_notification";

--- a/src/api/versions/v1/services/notification-service.ts
+++ b/src/api/versions/v1/services/notification-service.ts
@@ -1,5 +1,8 @@
 import { injectable } from "@needle-di/core";
-import { NOTIFICATION_EVENT } from "../constants/event-constants.ts";
+import {
+  GLOBAL_NOTIFICATION_EVENT,
+  USER_NOTIFICATION_EVENT,
+} from "../constants/event-constants.ts";
 import { ServerError } from "../models/server-error.ts";
 
 @injectable()
@@ -16,8 +19,29 @@ export class NotificationService {
       );
     }
 
-    const customEvent = new CustomEvent(NOTIFICATION_EVENT, {
+    const customEvent = new CustomEvent(GLOBAL_NOTIFICATION_EVENT, {
       detail: {
+        message,
+      },
+    });
+
+    dispatchEvent(customEvent);
+  }
+
+  public notifyUser(userId: string, text: string): void {
+    const message = text.trim();
+
+    if (message.length === 0) {
+      throw new ServerError(
+        "EMPTY_NOTIFICATION_MESSAGE",
+        "Notification message cannot be empty",
+        400,
+      );
+    }
+
+    const customEvent = new CustomEvent(USER_NOTIFICATION_EVENT, {
+      detail: {
+        userId,
         message,
       },
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import { Container } from "@needle-di/core";
 import { HTTPService } from "./core/services/http-service.ts";
 import { KVService } from "./core/services/kv-service.ts";
-import { NOTIFICATION_EVENT } from "./api/versions/v1/constants/event-constants.ts";
+import { GLOBAL_NOTIFICATION_EVENT } from "./api/versions/v1/constants/event-constants.ts";
 
 Deno.cron("Test server notification", "*/10 * * * *", () => {
   dispatchEvent(
-    new CustomEvent(NOTIFICATION_EVENT, {
+    new CustomEvent(GLOBAL_NOTIFICATION_EVENT, {
       detail: {
         message: `This is a server notification at ${new Date().toISOString()}`,
       },


### PR DESCRIPTION
## Summary
- notify individual users through websocket service via custom event
- add USER_NOTIFICATION_EVENT and notificationService.notifyUser
- dispatch user notifications on new highest scores
- rename global notification event constant

## Testing
- `deno task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1ccb9f908327aebdc6be1410067c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-specific notifications, allowing targeted messages to individual users.
  * Players now receive a notification when they achieve the highest score.

* **Improvements**
  * Notifications are now separated into global and user-specific types for clearer communication.

* **Bug Fixes**
  * Ensured empty notification messages are not sent to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->