### PR TITLE
Implement user moderation

### DIFF
--- a/src/api/versions/v1/interfaces/kv/user-kv.ts
+++ b/src/api/versions/v1/interfaces/kv/user-kv.ts
@@ -1,5 +1,11 @@
+export interface BanInformation {
+  reason: string;
+  expiresAt: number | null;
+}
+
 export interface UserKV {
   userId: string;
   displayName: string;
   createdAt: number;
+  ban?: BanInformation;
 }

--- a/src/api/versions/v1/routers/management-router.ts
+++ b/src/api/versions/v1/routers/management-router.ts
@@ -5,6 +5,7 @@ import { ManagementNotificationRouter } from "./management/management-notificati
 import { ManagementMessageRouter } from "./management/management-message-router.ts";
 import { ManagementConfigurationRouter } from "./management/management-configuration-router.ts";
 import { ManagementVersionRouter } from "./management/management-version-router.ts";
+import { ManagementModerationRouter } from "./management/management-moderation-router.ts";
 
 @injectable()
 export class V1ManagementRouter {
@@ -16,6 +17,7 @@ export class V1ManagementRouter {
     private configurationRouter = inject(ManagementConfigurationRouter),
     private messageRouter = inject(ManagementMessageRouter),
     private notificationRouter = inject(ManagementNotificationRouter),
+    private moderationRouter = inject(ManagementModerationRouter),
   ) {
     this.app = new OpenAPIHono();
     this.setMiddlewares();
@@ -39,5 +41,6 @@ export class V1ManagementRouter {
     this.app.route("/game-configuration", this.configurationRouter.getRouter());
     this.app.route("/server-messages", this.messageRouter.getRouter());
     this.app.route("/server-notification", this.notificationRouter.getRouter());
+    this.app.route("/moderation", this.moderationRouter.getRouter());
   }
 }

--- a/src/api/versions/v1/routers/management/management-moderation-router.ts
+++ b/src/api/versions/v1/routers/management/management-moderation-router.ts
@@ -1,0 +1,86 @@
+import { inject, injectable } from "@needle-di/core";
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { ModerationService } from "../../services/moderation-service.ts";
+import {
+  BanUserRequestSchema,
+  UnbanUserRequestSchema,
+} from "../../schemas/moderation-schemas.ts";
+import { ServerResponse } from "../../models/server-response.ts";
+
+@injectable()
+export class ManagementModerationRouter {
+  private app: OpenAPIHono;
+
+  constructor(private moderationService = inject(ModerationService)) {
+    this.app = new OpenAPIHono();
+    this.setRoutes();
+  }
+
+  public getRouter(): OpenAPIHono {
+    return this.app;
+  }
+
+  private setRoutes(): void {
+    this.registerBanUserRoute();
+    this.registerUnbanUserRoute();
+  }
+
+  private registerBanUserRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "post",
+        path: "/ban",
+        summary: "Ban user",
+        description: "Temporarily or permanently bans a user",
+        tags: ["Moderation"],
+        request: {
+          body: {
+            content: {
+              "application/json": {
+                schema: BanUserRequestSchema,
+              },
+            },
+          },
+        },
+        responses: {
+          ...ServerResponse.NoContent,
+          ...ServerResponse.BadRequest,
+          ...ServerResponse.Unauthorized,
+          ...ServerResponse.Forbidden,
+          ...ServerResponse.NotFound,
+        },
+      }),
+      async (c) => {
+        const validated = c.req.valid("json");
+        await this.moderationService.banUser(validated);
+        return c.body(null, 204);
+      },
+    );
+  }
+
+  private registerUnbanUserRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "delete",
+        path: "/ban/:userId",
+        summary: "Unban user",
+        description: "Removes the ban for the specified user",
+        tags: ["Moderation"],
+        request: {
+          params: UnbanUserRequestSchema,
+        },
+        responses: {
+          ...ServerResponse.NoContent,
+          ...ServerResponse.Unauthorized,
+          ...ServerResponse.Forbidden,
+          ...ServerResponse.NotFound,
+        },
+      }),
+      async (c) => {
+        const userId = c.req.param("userId");
+        await this.moderationService.unbanUser(userId);
+        return c.body(null, 204);
+      },
+    );
+  }
+}

--- a/src/api/versions/v1/schemas/moderation-schemas.ts
+++ b/src/api/versions/v1/schemas/moderation-schemas.ts
@@ -1,0 +1,32 @@
+import { z } from "@hono/zod-openapi";
+
+export const BanUserRequestSchema = z.object({
+  userId: z
+    .string()
+    .length(32)
+    .describe("The user ID to ban")
+    .openapi({ example: "123e4567e89b12d3a456426614174000" }),
+  reason: z.string().min(1).describe("Reason for the ban").openapi({
+    example: "Toxic behaviour",
+  }),
+  expiresAt: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe("Timestamp when the ban expires or null for permanent")
+    .openapi({ example: 1740325296918 }),
+});
+
+export type BanUserRequest = z.infer<typeof BanUserRequestSchema>;
+
+export const UnbanUserRequestSchema = z.object({
+  userId: z
+    .string()
+    .length(32)
+    .describe("The user ID to unban")
+    .openapi({ example: "123e4567e89b12d3a456426614174000" }),
+});
+
+export type UnbanUserRequest = z.infer<typeof UnbanUserRequestSchema>;

--- a/src/api/versions/v1/services/authentication-service.ts
+++ b/src/api/versions/v1/services/authentication-service.ts
@@ -28,11 +28,11 @@ export class AuthenticationService {
   constructor(
     private kvService = inject(KVService),
     private jwtService = inject(JWTService),
-    private iceService = inject(ICEService)
+    private iceService = inject(ICEService),
   ) {}
 
   public async getOptions(
-    authenticationRequest: GetAuthenticationOptionsRequest
+    authenticationRequest: GetAuthenticationOptionsRequest,
   ): Promise<object> {
     const { transactionId } = authenticationRequest;
     const options = await generateAuthenticationOptions({
@@ -50,28 +50,28 @@ export class AuthenticationService {
 
   public async verifyResponse(
     connectionInfo: ConnInfo,
-    authenticationRequest: VerifyAuthenticationRequest
+    authenticationRequest: VerifyAuthenticationRequest,
   ): Promise<AuthenticationResponse> {
     const { transactionId } = authenticationRequest;
-    const authenticationResponse =
-      authenticationRequest.authenticationResponse as object as AuthenticationResponseJSON;
+    const authenticationResponse = authenticationRequest
+      .authenticationResponse as object as AuthenticationResponseJSON;
 
     const authenticationOptions = await this.getAuthenticationOptionsOrThrow(
-      transactionId
+      transactionId,
     );
 
     await this.kvService.deleteAuthenticationOptionsByTransactionId(
-      transactionId
+      transactionId,
     );
 
     const credentialKV = await this.getCredentialOrThrow(
-      authenticationResponse.id
+      authenticationResponse.id,
     );
 
     const verification = await this.verifyAuthenticationResponse(
       authenticationResponse,
       authenticationOptions,
-      credentialKV
+      credentialKV,
     );
 
     await this.updateCredentialCounter(credentialKV, verification);
@@ -83,8 +83,9 @@ export class AuthenticationService {
 
   public async getResponseForUser(
     connectionInfo: ConnInfo,
-    user: UserKV
+    user: UserKV,
   ): Promise<AuthenticationResponse> {
+    await this.ensureUserNotBanned(user);
     const key = await this.jwtService.getKey();
     const publicIp = connectionInfo.remote.address ?? null;
     const userId = user.userId;
@@ -94,12 +95,12 @@ export class AuthenticationService {
     const authenticationToken = await create(
       { alg: "HS512", typ: "JWT" },
       { id: userId, name: displayName },
-      key
+      key,
     );
 
     // Add session key for encryption/decryption
     const sessionKey: string = encodeBase64(
-      crypto.getRandomValues(new Uint8Array(32)).buffer
+      crypto.getRandomValues(new Uint8Array(32)).buffer,
     );
 
     await this.kvService.setKey(userId, sessionKey);
@@ -120,18 +121,18 @@ export class AuthenticationService {
   }
 
   private async getAuthenticationOptionsOrThrow(
-    transactionId: string
+    transactionId: string,
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    const authenticationOptions =
-      await this.kvService.getAuthenticationOptionsByTransactionId(
-        transactionId
+    const authenticationOptions = await this.kvService
+      .getAuthenticationOptionsByTransactionId(
+        transactionId,
       );
 
     if (authenticationOptions === null) {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_NOT_FOUND",
         "Authentication options not found",
-        400
+        400,
       );
     }
 
@@ -142,7 +143,7 @@ export class AuthenticationService {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_EXPIRED",
         "Authentication options expired",
-        400
+        400,
       );
     }
 
@@ -156,7 +157,7 @@ export class AuthenticationService {
       throw new ServerError(
         "CREDENTIAL_NOT_FOUND",
         "Credential not found",
-        400
+        400,
       );
     }
 
@@ -166,7 +167,7 @@ export class AuthenticationService {
   private async verifyAuthenticationResponse(
     authenticationResponse: AuthenticationResponseJSON,
     authenticationOptions: PublicKeyCredentialRequestOptionsJSON,
-    credentialKV: CredentialKV
+    credentialKV: CredentialKV,
   ): Promise<VerifiedAuthenticationResponse> {
     try {
       const verification = await verifyAuthenticationResponse({
@@ -186,7 +187,7 @@ export class AuthenticationService {
         throw new ServerError(
           "AUTHENTICATION_FAILED",
           "Authentication failed",
-          400
+          400,
         );
       }
 
@@ -196,14 +197,14 @@ export class AuthenticationService {
       throw new ServerError(
         "AUTHENTICATION_FAILED",
         "Authentication failed",
-        400
+        400,
       );
     }
   }
 
   private async updateCredentialCounter(
     credential: CredentialKV,
-    verification: VerifiedAuthenticationResponse
+    verification: VerifiedAuthenticationResponse,
   ): Promise<void> {
     const { authenticationInfo } = verification;
     credential.counter = authenticationInfo.newCounter;
@@ -212,7 +213,7 @@ export class AuthenticationService {
   }
 
   private async getUserOrThrowError(
-    credentialKV: CredentialKV
+    credentialKV: CredentialKV,
   ): Promise<UserKV> {
     const userId = credentialKV.userId;
     const user = await this.kvService.getUser(userId);
@@ -222,5 +223,18 @@ export class AuthenticationService {
     }
 
     return user;
+  }
+
+  private async ensureUserNotBanned(user: UserKV): Promise<void> {
+    if (user.ban) {
+      const { expiresAt, reason } = user.ban;
+
+      if (expiresAt !== null && expiresAt < Date.now()) {
+        delete user.ban;
+        await this.kvService.setUser(user.userId, user);
+      } else {
+        throw new ServerError("USER_BANNED", reason, 403);
+      }
+    }
   }
 }

--- a/src/api/versions/v1/services/moderation-service.ts
+++ b/src/api/versions/v1/services/moderation-service.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "@needle-di/core";
+import { KVService } from "../../../../core/services/kv-service.ts";
+import { ServerError } from "../models/server-error.ts";
+import { BanInformation } from "../interfaces/kv/user-kv.ts";
+import { BanUserRequest } from "../schemas/moderation-schemas.ts";
+
+@injectable()
+export class ModerationService {
+  constructor(private kvService = inject(KVService)) {}
+
+  public async banUser(body: BanUserRequest): Promise<void> {
+    const { userId, reason, expiresAt } = body;
+    const user = await this.kvService.getUser(userId);
+
+    if (user === null) {
+      throw new ServerError("USER_NOT_FOUND", "User not found", 404);
+    }
+
+    const ban: BanInformation = {
+      reason,
+      expiresAt: expiresAt ?? null,
+    };
+
+    user.ban = ban;
+
+    await this.kvService.setUser(userId, user);
+  }
+
+  public async unbanUser(userId: string): Promise<void> {
+    const user = await this.kvService.getUser(userId);
+
+    if (user === null) {
+      throw new ServerError("USER_NOT_FOUND", "User not found", 404);
+    }
+
+    if (user.ban) {
+      delete user.ban;
+      await this.kvService.setUser(userId, user);
+    }
+  }
+}

--- a/src/core/services/kv-service.ts
+++ b/src/core/services/kv-service.ts
@@ -34,8 +34,9 @@ export class KVService {
   }
 
   public async getVersion(): Promise<VersionKV | null> {
-    const entry: Deno.KvEntryMaybe<VersionKV> =
-      await this.getKv().get<VersionKV>([KV_VERSION]);
+    const entry: Deno.KvEntryMaybe<VersionKV> = await this.getKv().get<
+      VersionKV
+    >([KV_VERSION]);
 
     return entry.value;
   }
@@ -45,10 +46,10 @@ export class KVService {
   }
 
   public async getRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<RegistrationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> =
-      await this.getKv().get<RegistrationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> = await this.getKv()
+      .get<RegistrationOptionsKV>([
         KV_REGISTRATION_OPTIONS,
         transactionId,
       ]);
@@ -58,28 +59,28 @@ export class KVService {
 
   public async setRegistrationOptions(
     transactionId: string,
-    registrationOptions: RegistrationOptionsKV
+    registrationOptions: RegistrationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_REGISTRATION_OPTIONS, transactionId],
       registrationOptions,
       {
         expireIn: 60 * 1_000,
-      }
+      },
     );
   }
 
   public async deleteRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_REGISTRATION_OPTIONS, transactionId]);
   }
 
   public async getAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<AuthenticationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> =
-      await this.getKv().get<AuthenticationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> = await this.getKv()
+      .get<AuthenticationOptionsKV>([
         KV_AUTHENTICATION_OPTIONS,
         transactionId,
       ]);
@@ -89,35 +90,36 @@ export class KVService {
 
   public async setAuthenticationOptions(
     requestId: string,
-    authenticationOptions: AuthenticationOptionsKV
+    authenticationOptions: AuthenticationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_AUTHENTICATION_OPTIONS, requestId],
       authenticationOptions,
       {
         expireIn: 60 * 1_000,
-      }
+      },
     );
   }
 
   public async deleteAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_AUTHENTICATION_OPTIONS, transactionId]);
   }
 
   public async getCredential(
-    credentialId: string
+    credentialId: string,
   ): Promise<CredentialKV | null> {
-    const entry: Deno.KvEntryMaybe<CredentialKV> =
-      await this.getKv().get<CredentialKV>([KV_CREDENTIALS, credentialId]);
+    const entry: Deno.KvEntryMaybe<CredentialKV> = await this.getKv().get<
+      CredentialKV
+    >([KV_CREDENTIALS, credentialId]);
 
     return entry.value;
   }
 
   public async setCredential(
     credentialId: string,
-    credential: CredentialKV
+    credential: CredentialKV,
   ): Promise<void> {
     await this.getKv().set([KV_CREDENTIALS, credentialId], credential);
   }
@@ -131,8 +133,13 @@ export class KVService {
     return entry.value;
   }
 
+  public async setUser(userId: string, user: UserKV): Promise<void> {
+    await this.getKv().set([KV_USERS, userId], user);
+    await this.getKv().set([KV_USERS_BY_DISPLAY_NAME, user.displayName], user);
+  }
+
   public async getUserByDisplayName(
-    displayName: string
+    displayName: string,
   ): Promise<UserKV | null> {
     const entry: Deno.KvEntryMaybe<UserKV> = await this.getKv().get<UserKV>([
       KV_USERS_BY_DISPLAY_NAME,
@@ -144,7 +151,7 @@ export class KVService {
 
   public async setCredentialAndUser(
     credential: CredentialKV,
-    user: UserKV
+    user: UserKV,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     const displayNameKey = [KV_USERS_BY_DISPLAY_NAME, user.displayName];
 
@@ -158,14 +165,15 @@ export class KVService {
   }
 
   public async getConfiguration(): Promise<ConfigurationType | null> {
-    const entry: Deno.KvEntryMaybe<ConfigurationType> =
-      await this.getKv().get<ConfigurationType>([KV_CONFIGURATION]);
+    const entry: Deno.KvEntryMaybe<ConfigurationType> = await this.getKv().get<
+      ConfigurationType
+    >([KV_CONFIGURATION]);
 
     return entry.value;
   }
 
   public async setConfiguration(
-    configuration: ConfigurationType
+    configuration: ConfigurationType,
   ): Promise<void> {
     await this.getKv().set([KV_CONFIGURATION], configuration);
   }
@@ -186,8 +194,9 @@ export class KVService {
   }
 
   public async getSession(token: string): Promise<SessionKV | null> {
-    const entry: Deno.KvEntryMaybe<SessionKV> =
-      await this.getKv().get<SessionKV>([KV_SESSIONS, token]);
+    const entry: Deno.KvEntryMaybe<SessionKV> = await this.getKv().get<
+      SessionKV
+    >([KV_SESSIONS, token]);
 
     return entry.value;
   }
@@ -229,7 +238,7 @@ export class KVService {
 
   public async setMatch(
     userId: string,
-    match: MatchKV
+    match: MatchKV,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     return await this.getKv()
       .atomic()
@@ -240,7 +249,7 @@ export class KVService {
   }
 
   public async deleteMatch(
-    userId: string
+    userId: string,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     return await this.getKv().atomic().delete([KV_MATCHES, userId]).commit();
   }
@@ -265,7 +274,7 @@ export class KVService {
   }
 
   public async deleteUserTemporaryData(
-    userId: string
+    userId: string,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     return await this.getKv()
       .atomic()


### PR DESCRIPTION
## Summary
- add BanInformation interface and store in user records
- implement ModerationService to ban/unban players
- register moderation router for management endpoints
- check for active bans during login

## Testing
- `deno fmt src/api/versions/v1/interfaces/kv/user-kv.ts src/api/versions/v1/services/moderation-service.ts`
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6872720e126083278f48d1ae55558a1c