### PR TITLE
Fix OpenAPI tags

### DIFF
--- a/src/core/routers/root_rooter.ts
+++ b/src/core/routers/root_rooter.ts
@@ -27,6 +27,7 @@ export class RootRouter {
         path: "/health",
         summary: "Get health",
         description: "Obtains health related to this server",
+        tags: ["Root"],
         responses: {
           204: {
             description: "Responds with no content",
@@ -46,6 +47,7 @@ export class RootRouter {
         path: "/game",
         summary: "Get game",
         description: "Obtains game associated with this server",
+        tags: ["Root"],
         responses: {
           307: {
             description: "Responds with temporary redirect",

--- a/src/core/services/openapi-service.ts
+++ b/src/core/services/openapi-service.ts
@@ -11,6 +11,16 @@ export class OpenAPIService {
       scheme: "bearer",
       bearerFormat: "JWT",
     });
+
+    app.openAPIRegistry.registerTag("Root", {
+      name: "Root",
+      description: "Server root endpoints",
+    });
+
+    app.openAPIRegistry.registerTag("Moderation", {
+      name: "Moderation",
+      description: "User banning and unbanning",
+    });
   }
 
   public static setRoutes(


### PR DESCRIPTION
## Summary
- add `Root` tag to health and game endpoints
- register "Root" and "Moderation" tags for OpenAPI

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68727ad7473083279fcdb5c1d7f01cab