### PR TITLE
Improve banned message

### DIFF
--- a/src/api/versions/v1/constants/api-constants.ts
+++ b/src/api/versions/v1/constants/api-constants.ts
@@ -5,3 +5,5 @@ export const DEFAULT_ICE_SERVERS = [
   { urls: "stun:stun3.l.google.com:19302" },
   { urls: "stun:stun4.l.google.com:19302" },
 ];
+
+export const BAN_MESSAGE_TEMPLATE = "You are {type} banned due to {reason}";

--- a/src/api/versions/v1/services/authentication-service.ts
+++ b/src/api/versions/v1/services/authentication-service.ts
@@ -22,6 +22,7 @@ import {
   VerifyAuthenticationRequest,
 } from "../schemas/authentication-schemas.ts";
 import { KV_OPTIONS_EXPIRATION_TIME } from "../constants/kv-constants.ts";
+import { BAN_MESSAGE_TEMPLATE } from "../constants/api-constants.ts";
 
 @injectable()
 export class AuthenticationService {
@@ -233,7 +234,10 @@ export class AuthenticationService {
         user.ban = undefined;
         await this.kvService.setUser(user.userId, user);
       } else {
-        throw new ServerError("USER_BANNED", reason, 403);
+        const banType = expiresAt === null ? "permanently" : "temporarily";
+        const message = BAN_MESSAGE_TEMPLATE.replace("{type}", banType)
+          .replace("{reason}", reason.toLowerCase());
+        throw new ServerError("USER_BANNED", message, 403);
       }
     }
   }


### PR DESCRIPTION
## Summary
- clarify response when checking banned user state
- move banned message template to API constants
- lower case the ban reason for consistency

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687282cada7083279bd856005fb852f5