### PR TITLE
Improve display name exists wording

### DIFF
--- a/src/api/versions/v1/routers/public/public-registration-router.ts
+++ b/src/api/versions/v1/routers/public/public-registration-router.ts
@@ -57,7 +57,7 @@ export class PublicRegistrationRouter {
           },
           409: {
             description:
-              "Responds with an error due to display name being already taken",
+              "Responds with an error when the chosen display name is already taken",
             content: {
               "application/json": {
                 schema: ErrorResponseSchema,

--- a/src/api/versions/v1/services/registration-service.ts
+++ b/src/api/versions/v1/services/registration-service.ts
@@ -93,7 +93,7 @@ export class RegistrationService {
     if (existingUser !== null) {
       throw new ServerError(
         "DISPLAY_NAME_TAKEN",
-        "Display name already exists",
+        "Display name is already taken",
         409,
       );
     }


### PR DESCRIPTION
## Summary
- use friendlier wording when a display name is already taken
- update API doc string accordingly

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6872881c66ac832781b864b1ec63d57e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the description of the error response for display name conflicts during registration.

* **Style**
  * Updated the error message shown when a display name is already taken for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->