### PR TITLE
Centralize error response texts

### DIFF
--- a/src/api/middlewares/authentication-middleware.ts
+++ b/src/api/middlewares/authentication-middleware.ts
@@ -2,6 +2,9 @@ import { createMiddleware } from "hono/factory";
 import { inject, injectable } from "@needle-di/core";
 import { ServerError } from "../versions/v1/models/server-error.ts";
 import { JWTService } from "../../core/services/jwt-service.ts";
+import {
+  NO_TOKEN_PROVIDED_MESSAGE,
+} from "../versions/v1/constants/api-constants.ts";
 
 @injectable()
 export class AuthenticationMiddleware {
@@ -33,7 +36,11 @@ export class AuthenticationMiddleware {
       : authorization.replace("Bearer", "").trim();
 
     if (token === null || token.length === 0) {
-      throw new ServerError("NO_TOKEN_PROVIDED", "No token provided", 401);
+      throw new ServerError(
+        "NO_TOKEN_PROVIDED",
+        NO_TOKEN_PROVIDED_MESSAGE,
+        401,
+      );
     }
 
     return token;

--- a/src/api/middlewares/authorization-middleware.ts
+++ b/src/api/middlewares/authorization-middleware.ts
@@ -1,6 +1,9 @@
 import { createMiddleware } from "hono/factory";
 import { injectable } from "@needle-di/core";
 import { ServerError } from "../versions/v1/models/server-error.ts";
+import {
+  MISSING_MANAGEMENT_ROLE_MESSAGE,
+} from "../versions/v1/constants/api-constants.ts";
 
 @injectable()
 export class AuthorizationMiddleware {
@@ -16,7 +19,7 @@ export class AuthorizationMiddleware {
     if (roles.includes("management") === false) {
       throw new ServerError(
         "NO_MANAGEMENT_ROLE",
-        "Missing management role",
+        MISSING_MANAGEMENT_ROLE_MESSAGE,
         403,
       );
     }

--- a/src/api/versions/v1/constants/api-constants.ts
+++ b/src/api/versions/v1/constants/api-constants.ts
@@ -7,3 +7,37 @@ export const DEFAULT_ICE_SERVERS = [
 ];
 
 export const BAN_MESSAGE_TEMPLATE = "You are {type} banned due to {reason}";
+
+export const BODY_SIZE_LIMIT_EXCEEDED_MESSAGE =
+  "Request body size limit exceeded";
+export const INVALID_TOKEN_MESSAGE = "Invalid token";
+export const NO_SESSION_KEY_MESSAGE = "No session found for this user";
+export const NO_TOKEN_PROVIDED_MESSAGE = "No token provided";
+export const MISSING_MANAGEMENT_ROLE_MESSAGE = "Missing management role";
+export const MISSING_VERSION_MESSAGE =
+  "Missing version information on the server";
+export const EMPTY_NOTIFICATION_MESSAGE =
+  "Notification message cannot be empty";
+export const CONFIGURATION_NOT_FOUND_MESSAGE = "Configuration not found";
+export const NO_MATCH_FOUND_MESSAGE = "User is not hosting a match";
+export const BAD_REQUEST_MESSAGE = "Invalid request body";
+export const USER_NOT_FOUND_MESSAGE = "User not found";
+export const AUTHENTICATION_OPTIONS_NOT_FOUND_MESSAGE =
+  "Authentication options not found";
+export const AUTHENTICATION_OPTIONS_EXPIRED_MESSAGE =
+  "Authentication options expired";
+export const CREDENTIAL_NOT_FOUND_MESSAGE = "Credential not found";
+export const AUTHENTICATION_FAILED_MESSAGE = "Authentication failed";
+export const NO_SESSION_FOUND_MESSAGE = "User session not found";
+export const MATCH_CREATION_FAILED_MESSAGE = "Match creation failed";
+export const MATCH_DELETION_FAILED_MESSAGE = "Match deletion failed";
+export const DISPLAY_NAME_TAKEN_MESSAGE = "Display name is already taken";
+export const REGISTRATION_OPTIONS_NOT_FOUND_MESSAGE =
+  "Registration options not found";
+export const REGISTRATION_OPTIONS_EXPIRED_MESSAGE =
+  "Registration options expired";
+export const REGISTRATION_VERIFICATION_FAILED_MESSAGE =
+  "Registration verification failed";
+export const CREDENTIAL_USER_ADD_FAILED_MESSAGE =
+  "Failed to add credential and user";
+export const INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error";

--- a/src/api/versions/v1/services/authentication-service.ts
+++ b/src/api/versions/v1/services/authentication-service.ts
@@ -22,7 +22,14 @@ import {
   VerifyAuthenticationRequest,
 } from "../schemas/authentication-schemas.ts";
 import { KV_OPTIONS_EXPIRATION_TIME } from "../constants/kv-constants.ts";
-import { BAN_MESSAGE_TEMPLATE } from "../constants/api-constants.ts";
+import {
+  AUTHENTICATION_FAILED_MESSAGE,
+  AUTHENTICATION_OPTIONS_EXPIRED_MESSAGE,
+  AUTHENTICATION_OPTIONS_NOT_FOUND_MESSAGE,
+  BAN_MESSAGE_TEMPLATE,
+  CREDENTIAL_NOT_FOUND_MESSAGE,
+  USER_NOT_FOUND_MESSAGE,
+} from "../constants/api-constants.ts";
 
 @injectable()
 export class AuthenticationService {
@@ -132,7 +139,7 @@ export class AuthenticationService {
     if (authenticationOptions === null) {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_NOT_FOUND",
-        "Authentication options not found",
+        AUTHENTICATION_OPTIONS_NOT_FOUND_MESSAGE,
         400,
       );
     }
@@ -143,7 +150,7 @@ export class AuthenticationService {
     if (createdAt + KV_OPTIONS_EXPIRATION_TIME < Date.now()) {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_EXPIRED",
-        "Authentication options expired",
+        AUTHENTICATION_OPTIONS_EXPIRED_MESSAGE,
         400,
       );
     }
@@ -157,7 +164,7 @@ export class AuthenticationService {
     if (credential === null) {
       throw new ServerError(
         "CREDENTIAL_NOT_FOUND",
-        "Credential not found",
+        CREDENTIAL_NOT_FOUND_MESSAGE,
         400,
       );
     }
@@ -187,7 +194,7 @@ export class AuthenticationService {
       if (verification.verified === false) {
         throw new ServerError(
           "AUTHENTICATION_FAILED",
-          "Authentication failed",
+          AUTHENTICATION_FAILED_MESSAGE,
           400,
         );
       }
@@ -197,7 +204,7 @@ export class AuthenticationService {
       console.error(error);
       throw new ServerError(
         "AUTHENTICATION_FAILED",
-        "Authentication failed",
+        AUTHENTICATION_FAILED_MESSAGE,
         400,
       );
     }
@@ -220,7 +227,7 @@ export class AuthenticationService {
     const user = await this.kvService.getUser(userId);
 
     if (user === null) {
-      throw new ServerError("USER_NOT_FOUND", "User not found", 400);
+      throw new ServerError("USER_NOT_FOUND", USER_NOT_FOUND_MESSAGE, 400);
     }
 
     return user;

--- a/src/api/versions/v1/services/configuration-service.ts
+++ b/src/api/versions/v1/services/configuration-service.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "@needle-di/core";
 import { KVService } from "../../../../core/services/kv-service.ts";
 import { ServerError } from "../models/server-error.ts";
+import { CONFIGURATION_NOT_FOUND_MESSAGE } from "../constants/api-constants.ts";
 import { CryptoService } from "../../../../core/services/crypto-service.ts";
 import {
   GetConfigurationResponse,
@@ -20,7 +21,7 @@ export class ConfigurationService {
     if (configuration === null) {
       throw new ServerError(
         "CONFIGURATION_NOT_FOUND",
-        "Configuration not found",
+        CONFIGURATION_NOT_FOUND_MESSAGE,
         404,
       );
     }
@@ -40,7 +41,7 @@ export class ConfigurationService {
     if (configuration === null) {
       throw new ServerError(
         "CONFIGURATION_NOT_FOUND",
-        "Configuration not found",
+        CONFIGURATION_NOT_FOUND_MESSAGE,
         404,
       );
     }

--- a/src/api/versions/v1/services/matches-service.ts
+++ b/src/api/versions/v1/services/matches-service.ts
@@ -8,6 +8,11 @@ import { KVService } from "../../../../core/services/kv-service.ts";
 import { SessionKV } from "../interfaces/kv/session-kv.ts";
 import { MatchKV } from "../interfaces/kv/match_kv.ts";
 import { ServerError } from "../models/server-error.ts";
+import {
+  MATCH_CREATION_FAILED_MESSAGE,
+  MATCH_DELETION_FAILED_MESSAGE,
+  NO_SESSION_FOUND_MESSAGE,
+} from "../constants/api-constants.ts";
 
 @injectable()
 export class MatchesService {
@@ -21,7 +26,11 @@ export class MatchesService {
     const session: SessionKV | null = await this.kvService.getSession(userId);
 
     if (session === null) {
-      throw new ServerError("NO_SESSION_FOUND", "User session not found", 400);
+      throw new ServerError(
+        "NO_SESSION_FOUND",
+        NO_SESSION_FOUND_MESSAGE,
+        400,
+      );
     }
 
     const { token } = session;
@@ -41,7 +50,7 @@ export class MatchesService {
     if (response.ok === false) {
       throw new ServerError(
         "MATCH_CREATION_FAILED",
-        "Match creation failed",
+        MATCH_CREATION_FAILED_MESSAGE,
         500,
       );
     }
@@ -66,7 +75,7 @@ export class MatchesService {
     if (response.ok === false) {
       throw new ServerError(
         "MATCH_DELETION_FAILED",
-        "Match deletion failed",
+        MATCH_DELETION_FAILED_MESSAGE,
         500,
       );
     }

--- a/src/api/versions/v1/services/moderation-service.ts
+++ b/src/api/versions/v1/services/moderation-service.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "@needle-di/core";
 import { KVService } from "../../../../core/services/kv-service.ts";
 import { ServerError } from "../models/server-error.ts";
+import { USER_NOT_FOUND_MESSAGE } from "../constants/api-constants.ts";
 import { BanInformation } from "../interfaces/kv/user-kv.ts";
 import { BanUserRequest } from "../schemas/moderation-schemas.ts";
 
@@ -13,7 +14,7 @@ export class ModerationService {
     const user = await this.kvService.getUser(userId);
 
     if (user === null) {
-      throw new ServerError("USER_NOT_FOUND", "User not found", 404);
+      throw new ServerError("USER_NOT_FOUND", USER_NOT_FOUND_MESSAGE, 404);
     }
 
     const ban: BanInformation = {
@@ -30,7 +31,7 @@ export class ModerationService {
     const user = await this.kvService.getUser(userId);
 
     if (user === null) {
-      throw new ServerError("USER_NOT_FOUND", "User not found", 404);
+      throw new ServerError("USER_NOT_FOUND", USER_NOT_FOUND_MESSAGE, 404);
     }
 
     if (user.ban) {

--- a/src/api/versions/v1/services/notification-service.ts
+++ b/src/api/versions/v1/services/notification-service.ts
@@ -1,6 +1,7 @@
 import { injectable } from "@needle-di/core";
 import { NOTIFICATION_EVENT } from "../constants/event-constants.ts";
 import { ServerError } from "../models/server-error.ts";
+import { EMPTY_NOTIFICATION_MESSAGE } from "../constants/api-constants.ts";
 
 @injectable()
 export class NotificationService {
@@ -11,7 +12,7 @@ export class NotificationService {
     if (message.length === 0) {
       throw new ServerError(
         "EMPTY_NOTIFICATION_MESSAGE",
-        "Notification message cannot be empty",
+        EMPTY_NOTIFICATION_MESSAGE,
         400,
       );
     }

--- a/src/api/versions/v1/services/registration-service.ts
+++ b/src/api/versions/v1/services/registration-service.ts
@@ -2,6 +2,13 @@ import { inject, injectable } from "@needle-di/core";
 import { KVService } from "../../../../core/services/kv-service.ts";
 import { ServerError } from "../models/server-error.ts";
 import {
+  CREDENTIAL_USER_ADD_FAILED_MESSAGE,
+  DISPLAY_NAME_TAKEN_MESSAGE,
+  REGISTRATION_OPTIONS_EXPIRED_MESSAGE,
+  REGISTRATION_OPTIONS_NOT_FOUND_MESSAGE,
+  REGISTRATION_VERIFICATION_FAILED_MESSAGE,
+} from "../constants/api-constants.ts";
+import {
   generateRegistrationOptions,
   PublicKeyCredentialCreationOptionsJSON,
   VerifiedRegistrationResponse,
@@ -93,7 +100,7 @@ export class RegistrationService {
     if (existingUser !== null) {
       throw new ServerError(
         "DISPLAY_NAME_TAKEN",
-        "Display name is already taken",
+        DISPLAY_NAME_TAKEN_MESSAGE,
         409,
       );
     }
@@ -108,7 +115,7 @@ export class RegistrationService {
     if (registrationOptions === null) {
       throw new ServerError(
         "REGISTRATION_OPTIONS_NOT_FOUND",
-        "Registration options not found",
+        REGISTRATION_OPTIONS_NOT_FOUND_MESSAGE,
         400,
       );
     }
@@ -119,7 +126,7 @@ export class RegistrationService {
     if (createdAt + KV_OPTIONS_EXPIRATION_TIME < Date.now()) {
       throw new ServerError(
         "REGISTRATION_OPTIONS_EXPIRED",
-        "Registration options expired",
+        REGISTRATION_OPTIONS_EXPIRED_MESSAGE,
         400,
       );
     }
@@ -152,7 +159,7 @@ export class RegistrationService {
 
       throw new ServerError(
         "REGISTRATION_VERIFICATION_FAILED",
-        "Registration verification failed",
+        REGISTRATION_VERIFICATION_FAILED_MESSAGE,
         400,
       );
     }
@@ -204,7 +211,7 @@ export class RegistrationService {
     if (result.ok === false) {
       throw new ServerError(
         "CREDENTIAL_USER_ADD_FAILED",
-        "Failed to add credential and user",
+        CREDENTIAL_USER_ADD_FAILED_MESSAGE,
         500,
       );
     }

--- a/src/api/versions/v1/services/version-service.ts
+++ b/src/api/versions/v1/services/version-service.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "@needle-di/core";
 import { KVService } from "../../../../core/services/kv-service.ts";
 import { ServerError } from "../models/server-error.ts";
+import { MISSING_VERSION_MESSAGE } from "../constants/api-constants.ts";
 import {
   GetVersionResponse,
   UpdateVersionRequest,
@@ -16,7 +17,7 @@ export class VersionService {
     if (response === null) {
       throw new ServerError(
         "MISSING_VERSION",
-        "Missing version information on the server",
+        MISSING_VERSION_MESSAGE,
         404,
       );
     }

--- a/src/core/services/crypto-service.ts
+++ b/src/core/services/crypto-service.ts
@@ -1,5 +1,8 @@
 import { inject, injectable } from "@needle-di/core";
 import { ServerError } from "../../api/versions/v1/models/server-error.ts";
+import {
+  NO_SESSION_KEY_MESSAGE,
+} from "../../api/versions/v1/constants/api-constants.ts";
 import { CryptoUtils } from "../utils/crypto-utils.ts";
 import { KVService } from "./kv-service.ts";
 
@@ -16,7 +19,7 @@ export class CryptoService {
     if (key === null) {
       throw new ServerError(
         "NO_SESSION_KEY",
-        "No session found for this user",
+        NO_SESSION_KEY_MESSAGE,
         400,
       );
     }
@@ -42,7 +45,7 @@ export class CryptoService {
     if (key === null) {
       throw new ServerError(
         "NO_SESSION_KEY",
-        "No session found for this user",
+        NO_SESSION_KEY_MESSAGE,
         400,
       );
     }

--- a/src/core/services/error-handling-service.ts
+++ b/src/core/services/error-handling-service.ts
@@ -2,6 +2,9 @@ import { HTTPException } from "hono/http-exception";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { ServerError } from "../../api/versions/v1/models/server-error.ts";
 import { HonoVariablesType } from "../types/hono-variables-type.ts";
+import {
+  INTERNAL_SERVER_ERROR_MESSAGE,
+} from "../../api/versions/v1/constants/api-constants.ts";
 
 export class ErrorHandlingService {
   public static configure(
@@ -25,7 +28,7 @@ export class ErrorHandlingService {
       }
 
       return c.json(
-        this.createResponse("FATAL_ERROR", "Internal server error"),
+        this.createResponse("FATAL_ERROR", INTERNAL_SERVER_ERROR_MESSAGE),
         500,
       );
     });

--- a/src/core/services/http-service.ts
+++ b/src/core/services/http-service.ts
@@ -7,6 +7,9 @@ import { OpenAPIService } from "./openapi-service.ts";
 import { APIRouter } from "../../api/routers/api-router.ts";
 import { RootRouter } from "../routers/root_rooter.ts";
 import { ErrorHandlingService } from "./error-handling-service.ts";
+import {
+  BODY_SIZE_LIMIT_EXCEEDED_MESSAGE,
+} from "../../api/versions/v1/constants/api-constants.ts";
 import { HonoVariablesType } from "../types/hono-variables-type.ts";
 import { CORSMiddleware } from "../middlewares/cors-middleware.ts";
 import { ServerError } from "../../api/versions/v1/models/server-error.ts";
@@ -19,7 +22,7 @@ export class HTTPService {
   constructor(
     private kvService = inject(KVService),
     private rootRooter = inject(RootRouter),
-    private apiRouter = inject(APIRouter)
+    private apiRouter = inject(APIRouter),
   ) {
     this.app = new OpenAPIHono();
     this.configure();
@@ -51,11 +54,11 @@ export class HTTPService {
         onError: () => {
           throw new ServerError(
             "BODY_SIZE_LIMIT_EXCEEDED",
-            "Request body size limit exceeded",
-            413
+            BODY_SIZE_LIMIT_EXCEEDED_MESSAGE,
+            413,
           );
         },
-      })
+      }),
     );
   }
 

--- a/src/core/services/jwt-service.ts
+++ b/src/core/services/jwt-service.ts
@@ -3,6 +3,9 @@ import { CryptoUtils } from "../utils/crypto-utils.ts";
 import { injectable } from "@needle-di/core";
 import { ServerError } from "../../api/versions/v1/models/server-error.ts";
 import { ENV_JWT_SECRET } from "../../api/versions/v1/constants/env-constants.ts";
+import {
+  INVALID_TOKEN_MESSAGE,
+} from "../../api/versions/v1/constants/api-constants.ts";
 
 @injectable()
 export class JWTService {
@@ -45,7 +48,7 @@ export class JWTService {
     }
 
     if (payload === null) {
-      throw new ServerError("INVALID_TOKEN", "Invalid token", 401);
+      throw new ServerError("INVALID_TOKEN", INVALID_TOKEN_MESSAGE, 401);
     }
 
     return payload;


### PR DESCRIPTION
## Summary
- add string constants for server error messages
- reference the constants across middleware, services, and core utilities

## Testing
- `deno fmt src/api/versions/v1/constants/api-constants.ts src/core/services/http-service.ts src/core/services/jwt-service.ts src/core/services/crypto-service.ts src/core/services/error-handling-service.ts src/api/middlewares/authentication-middleware.ts src/api/middlewares/authorization-middleware.ts src/api/versions/v1/services/version-service.ts src/api/versions/v1/services/notification-service.ts src/api/versions/v1/services/configuration-service.ts src/api/versions/v1/services/scores-service.ts src/api/versions/v1/services/moderation-service.ts src/api/versions/v1/services/authentication-service.ts src/api/versions/v1/services/matches-service.ts src/api/versions/v1/services/registration-service.ts`
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68728c9b554483278ad200bb640187b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error messages across the application by replacing hardcoded strings with centralized, predefined constants for improved consistency and maintainability.
* **Chores**
  * Added a comprehensive set of new error and status message constants to support consistent messaging throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->