### PR TITLE
Add MatchPlayer websocket type

### DIFF
--- a/src/api/versions/v1/enums/websocket-enum.ts
+++ b/src/api/versions/v1/enums/websocket-enum.ts
@@ -3,4 +3,5 @@ export enum WebSocketType {
   PlayerIdentity = 1,
   Tunnel = 2,
   OnlinePlayers = 3,
+  MatchPlayer = 4,
 }

--- a/src/api/versions/v1/services/match-players-service.ts
+++ b/src/api/versions/v1/services/match-players-service.ts
@@ -32,6 +32,9 @@ export class MatchPlayersService {
       players.add(playerId);
     } else {
       players.delete(playerId);
+      if (players.size === 0) {
+        this.matchPlayers.delete(token);
+      }
     }
 
     const action = isConnected ? "joined" : "left";

--- a/src/api/versions/v1/services/match-players-service.ts
+++ b/src/api/versions/v1/services/match-players-service.ts
@@ -1,0 +1,50 @@
+import { inject, injectable } from "@needle-di/core";
+import { KVService } from "../../../../core/services/kv-service.ts";
+import { BinaryReader } from "../../../../core/utils/binary-reader-utils.ts";
+import { WebSocketUser } from "../models/websocket-user.ts";
+
+@injectable()
+export class MatchPlayersService {
+  private matchPlayers: Map<string, Set<string>>;
+
+  constructor(private kvService = inject(KVService)) {
+    this.matchPlayers = new Map();
+  }
+
+  public deleteByToken(token: string): void {
+    this.matchPlayers.delete(token);
+  }
+
+  public async handleMatchPlayerMessage(
+    originUser: WebSocketUser,
+    binaryReader: BinaryReader,
+  ): Promise<void> {
+    const isConnected = binaryReader.boolean();
+    const playerId = binaryReader.fixedLengthString(32);
+
+    const token = originUser.getToken();
+    let players = this.matchPlayers.get(token);
+    if (players === undefined) {
+      players = new Set<string>();
+      this.matchPlayers.set(token, players);
+    }
+
+    if (isConnected) {
+      players.add(playerId);
+    } else {
+      players.delete(playerId);
+    }
+
+    await this.logPlayerStatus(isConnected, playerId);
+  }
+
+  private async logPlayerStatus(
+    isConnected: boolean,
+    playerId: string,
+  ): Promise<void> {
+    const user = await this.kvService.getUser(playerId);
+    const playerName = user?.displayName ?? playerId;
+    const action = isConnected ? "joined" : "left";
+    console.log(`Player ${playerName} ${action} match`);
+  }
+}

--- a/src/api/versions/v1/services/match-players-service.ts
+++ b/src/api/versions/v1/services/match-players-service.ts
@@ -1,5 +1,4 @@
-import { inject, injectable } from "@needle-di/core";
-import { KVService } from "../../../../core/services/kv-service.ts";
+import { injectable } from "@needle-di/core";
 import { BinaryReader } from "../../../../core/utils/binary-reader-utils.ts";
 import { WebSocketUser } from "../models/websocket-user.ts";
 
@@ -7,7 +6,7 @@ import { WebSocketUser } from "../models/websocket-user.ts";
 export class MatchPlayersService {
   private matchPlayers: Map<string, Set<string>>;
 
-  constructor(private kvService = inject(KVService)) {
+  constructor() {
     this.matchPlayers = new Map();
   }
 
@@ -15,10 +14,10 @@ export class MatchPlayersService {
     this.matchPlayers.delete(token);
   }
 
-  public async handleMatchPlayerMessage(
+  public handleMatchPlayerMessage(
     originUser: WebSocketUser,
     binaryReader: BinaryReader,
-  ): Promise<void> {
+  ): void {
     const isConnected = binaryReader.boolean();
     const playerId = binaryReader.fixedLengthString(32);
 
@@ -35,16 +34,15 @@ export class MatchPlayersService {
       players.delete(playerId);
     }
 
-    await this.logPlayerStatus(isConnected, playerId);
+    this.logPlayerStatus(isConnected, playerId, token);
   }
 
-  private async logPlayerStatus(
+  private logPlayerStatus(
     isConnected: boolean,
     playerId: string,
-  ): Promise<void> {
-    const user = await this.kvService.getUser(playerId);
-    const playerName = user?.displayName ?? playerId;
+    token: string,
+  ): void {
     const action = isConnected ? "joined" : "left";
-    console.log(`Player ${playerName} ${action} match`);
+    console.log(`Player ${playerId} ${action} match ${token}`);
   }
 }

--- a/src/api/versions/v1/services/match-players-service.ts
+++ b/src/api/versions/v1/services/match-players-service.ts
@@ -34,14 +34,6 @@ export class MatchPlayersService {
       players.delete(playerId);
     }
 
-    this.logPlayerStatus(isConnected, playerId, token);
-  }
-
-  private logPlayerStatus(
-    isConnected: boolean,
-    playerId: string,
-    token: string,
-  ): void {
     const action = isConnected ? "joined" : "left";
     console.log(`Player ${playerId} ${action} match ${token}`);
   }


### PR DESCRIPTION
## Summary
- extend WebSocketType enum with `MatchPlayer`
- maintain match player lists per match token
- track players joining or leaving a match and log updates

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687363fb20a08327af3d61a3d38425cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking players joining or leaving matches in real-time via WebSocket connections.
  * Users will now receive updates when players connect to or disconnect from matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->