### PR TITLE
Add match tracking and chat support

### DIFF
--- a/src/api/versions/v1/enums/websocket-enum.ts
+++ b/src/api/versions/v1/enums/websocket-enum.ts
@@ -4,4 +4,5 @@ export enum WebSocketType {
   Tunnel = 2,
   OnlinePlayers = 3,
   MatchPlayer = 4,
+  ChatMessage = 5,
 }

--- a/src/api/versions/v1/models/websocket-user.ts
+++ b/src/api/versions/v1/models/websocket-user.ts
@@ -7,6 +7,7 @@ export class WebSocketUser {
   private name: string;
   private connectedTimestamp: number;
   private webSocket: WSContext<WebSocket> | null = null;
+  private matchId: string | null = null;
 
   constructor(id: string, name: string) {
     this.id = id;
@@ -33,6 +34,14 @@ export class WebSocketUser {
 
   public getWebSocket(): WSContext<WebSocket> | null {
     return this.webSocket;
+  }
+
+  public getMatchId(): string | null {
+    return this.matchId;
+  }
+
+  public setMatchId(matchId: string | null): void {
+    this.matchId = matchId;
   }
 
   public setWebSocket(webSocket: WSContext<WebSocket> | null): void {

--- a/src/api/versions/v1/services/chat-service.ts
+++ b/src/api/versions/v1/services/chat-service.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from "@needle-di/core";
+import { BinaryReader } from "../../../../core/utils/binary-reader-utils.ts";
+import { BinaryWriter } from "../../../../core/utils/binary-writer-utils.ts";
+import { WebSocketType } from "../enums/websocket-enum.ts";
+import { WebSocketUser } from "../models/websocket-user.ts";
+import { MatchPlayersService } from "./match-players-service.ts";
+
+@injectable()
+export class ChatService {
+  constructor(
+    private matchPlayersService = inject(MatchPlayersService),
+  ) {}
+
+  public handleChatMessage(
+    originUser: WebSocketUser,
+    binaryReader: BinaryReader,
+    usersById: Map<string, WebSocketUser>,
+    sendMessage: (user: WebSocketUser, payload: ArrayBuffer) => void,
+  ): void {
+    const content = binaryReader.variableLengthString();
+    const matchId = originUser.getMatchId();
+    if (!matchId) return;
+
+    const players = this.matchPlayersService.getPlayers(matchId);
+    if (!players) return;
+
+    const payload = BinaryWriter.build()
+      .unsignedInt8(WebSocketType.ChatMessage)
+      .fixedLengthString(originUser.getId(), 32)
+      .variableLengthString(content)
+      .toArrayBuffer();
+
+    for (const playerId of players) {
+      if (playerId === originUser.getId()) continue;
+      const playerUser = usersById.get(playerId);
+      if (playerUser) {
+        sendMessage(playerUser, payload);
+      }
+    }
+  }
+}

--- a/src/api/versions/v1/services/match-players-service.ts
+++ b/src/api/versions/v1/services/match-players-service.ts
@@ -14,18 +14,19 @@ export class MatchPlayersService {
     this.matchPlayers.delete(token);
   }
 
-  public handleMatchPlayerMessage(
-    originUser: WebSocketUser,
-    binaryReader: BinaryReader,
-  ): void {
-    const isConnected = binaryReader.boolean();
-    const playerId = binaryReader.fixedLengthString(32);
+  public getPlayers(matchId: string): Set<string> | undefined {
+    return this.matchPlayers.get(matchId);
+  }
 
-    const token = originUser.getToken();
-    let players = this.matchPlayers.get(token);
+  public updateMatchPlayers(
+    matchId: string,
+    playerId: string,
+    isConnected: boolean,
+  ): void {
+    let players = this.matchPlayers.get(matchId);
     if (players === undefined) {
       players = new Set<string>();
-      this.matchPlayers.set(token, players);
+      this.matchPlayers.set(matchId, players);
     }
 
     if (isConnected) {
@@ -33,11 +34,22 @@ export class MatchPlayersService {
     } else {
       players.delete(playerId);
       if (players.size === 0) {
-        this.matchPlayers.delete(token);
+        this.matchPlayers.delete(matchId);
       }
     }
+  }
+
+  public handleMatchPlayerMessage(
+    originUser: WebSocketUser,
+    binaryReader: BinaryReader,
+  ): void {
+    const isConnected = binaryReader.boolean();
+    const playerId = binaryReader.fixedLengthString(32);
+
+    const matchId = originUser.getToken();
+    this.updateMatchPlayers(matchId, playerId, isConnected);
 
     const action = isConnected ? "joined" : "left";
-    console.log(`Player ${playerId} ${action} match ${token}`);
+    console.log(`Player ${playerId} ${action} match ${matchId}`);
   }
 }


### PR DESCRIPTION
## Summary
- track players joining matches and assign match IDs to WebSocket users
- expose match players list and update logic
- add ChatMessage WebSocket command with broadcast implementation
- extract chat broadcasting logic to new ChatService

## Testing
- `deno task check` *(fails: invalid peer certificate when downloading npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_68737edc656c83279501d3a2f23d9650