### PR TITLE
Add host token tracking for WebSocket users

### DIFF
--- a/src/api/versions/v1/models/websocket-user.ts
+++ b/src/api/versions/v1/models/websocket-user.ts
@@ -3,7 +3,8 @@ import { AuthenticationUtils } from "../../../utils/authentication-utils.ts";
 
 export class WebSocketUser {
   private id: string;
-  private token: string;
+  private userToken: string;
+  private hostToken: string | null = null;
   private name: string;
   private connectedTimestamp: number;
   private webSocket: WSContext<WebSocket> | null = null;
@@ -11,7 +12,7 @@ export class WebSocketUser {
   constructor(id: string, name: string) {
     this.id = id;
     this.name = name;
-    this.token = AuthenticationUtils.generateToken();
+    this.userToken = AuthenticationUtils.generateToken();
     this.connectedTimestamp = Date.now();
   }
 
@@ -19,8 +20,16 @@ export class WebSocketUser {
     return this.id;
   }
 
-  public getToken(): string {
-    return this.token;
+  public getUserToken(): string {
+    return this.userToken;
+  }
+
+  public getHostToken(): string | null {
+    return this.hostToken;
+  }
+
+  public setHostToken(token: string | null): void {
+    this.hostToken = token;
   }
 
   public getName(): string {
@@ -42,7 +51,8 @@ export class WebSocketUser {
   public serialize(): string {
     return JSON.stringify({
       id: this.id,
-      token: this.token,
+      userToken: this.userToken,
+      hostToken: this.hostToken,
       name: this.name,
       connectedTimestamp: this.connectedTimestamp,
     });

--- a/src/api/versions/v1/services/match-players-service.ts
+++ b/src/api/versions/v1/services/match-players-service.ts
@@ -1,5 +1,4 @@
 import { injectable } from "@needle-di/core";
-import { BinaryReader } from "../../../../core/utils/binary-reader-utils.ts";
 import { WebSocketUser } from "../models/websocket-user.ts";
 
 @injectable()
@@ -16,12 +15,11 @@ export class MatchPlayersService {
 
   public handleMatchPlayerMessage(
     originUser: WebSocketUser,
-    binaryReader: BinaryReader,
+    isConnected: boolean,
+    playerId: string,
   ): void {
-    const isConnected = binaryReader.boolean();
-    const playerId = binaryReader.fixedLengthString(32);
 
-    const token = originUser.getToken();
+    const token = originUser.getUserToken();
     let players = this.matchPlayers.get(token);
     if (players === undefined) {
       players = new Set<string>();


### PR DESCRIPTION
## Summary
- rename `token` field in `WebSocketUser` to `userToken`
- add `hostToken` field with getters/setters
- update match player handling to set a player's `hostToken`
- adjust MatchPlayersService and WebSocketService to new API

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687384fe38648327a95b04aabc71e070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced user session handling by introducing separate user and host tokens for improved distinction and management.

* **Refactor**
  * Updated terminology and logic throughout the application to use user and host tokens, replacing previous single-token usage.
  * Streamlined message handling for player connections and identity management for greater clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->