### PR TITLE
Refine chat profanity filtering

### DIFF
--- a/src/api/versions/v4/data/block-words.json
+++ b/src/api/versions/v4/data/block-words.json
@@ -1,0 +1,7 @@
+[
+  "shit",
+  "fuck",
+  "asshole",
+  "bitch",
+  "bastard"
+]


### PR DESCRIPTION
## Summary
- replace each blocked word with the same number of asterisks
- keep broadcasting chat messages to players in a match via hostToken

## Testing
- `deno task check` *(fails to fetch npm packages: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6873c6f15fb88327a334236e78297849