### PR TITLE
Remove duplicated host chat relay

### DIFF
--- a/src/api/versions/v1/services/chat-service.ts
+++ b/src/api/versions/v1/services/chat-service.ts
@@ -62,10 +62,6 @@ export class ChatService {
       .variableLengthString(message)
       .toArrayBuffer();
 
-    const hostUser = wsAdapter.getUserByToken(hostToken);
-    if (hostUser) {
-      wsAdapter.sendMessage(hostUser, payload);
-    }
 
     for (const playerId of this.matchPlayersService.getPlayersByToken(hostToken)) {
       const target = wsAdapter.getUserById(playerId);


### PR DESCRIPTION
## Summary
- remove host relay snippet from chat service

## Testing
- `deno task check` *(fails: invalid peer certificate for npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_687400a484ac83278fc3d5859f21a430