### PR TITLE
Migrate to zod v4 schema APIs

### DIFF
--- a/src/api/versions/v1/schemas/authentication-schemas.ts
+++ b/src/api/versions/v1/schemas/authentication-schemas.ts
@@ -13,7 +13,6 @@ export type RTCIceServer = z.infer<typeof RTCIceServerSchema>;
 
 export const GetAuthenticationOptionsRequestSchema = z.object({
   transactionId: z
-    .string()
     .uuid()
     .describe("The transaction ID for the authentication request")
     .openapi({
@@ -26,8 +25,7 @@ export type GetAuthenticationOptionsRequest = z.infer<
 >;
 
 export const GetAuthenticationOptionsResponseSchema = z
-  .object({})
-  .passthrough()
+  .looseObject({})
   .describe("The authentication options required by the server")
   .openapi({
     example: {
@@ -44,15 +42,13 @@ export type GetAuthenticationOptionsResponse = z.infer<
 
 export const VerifyAuthenticationRequestSchema = z.object({
   transactionId: z
-    .string()
     .uuid()
     .describe("The transaction ID for the authentication request")
     .openapi({
       example: "123e4567-e89b-12d3-a456-426614174000",
     }),
   authenticationResponse: z
-    .object({})
-    .passthrough()
+    .looseObject({})
     .describe("The authentication response from the authenticator"),
 });
 
@@ -68,8 +64,7 @@ export const VerifyAuthenticationResponseSchema = z.object({
     .describe("The authentication token of the user"),
   sessionKey: z.string().describe("The session key of the user"),
   publicIp: z
-    .string()
-    .ip()
+    .union([z.ipv4(), z.ipv6()])
     .nullable()
     .describe("The public IP of the user")
     .openapi({ example: "…" }),

--- a/src/api/versions/v1/schemas/configuration-schemas.ts
+++ b/src/api/versions/v1/schemas/configuration-schemas.ts
@@ -1,8 +1,7 @@
 import { z } from "@hono/zod-openapi";
 
 export const UpdateConfigurationRequestSchema = z
-  .object({})
-  .passthrough()
+  .looseObject({})
   .describe("The cloud game configuration from the server")
   .openapi({
     example: {
@@ -16,8 +15,7 @@ export type UpdateConfigurationRequest = z.infer<
 >;
 
 export const GetConfigurationResponseSchema = z
-  .object({})
-  .passthrough()
+  .looseObject({})
   .describe("The cloud game configuration from the server")
   .openapi({
     example: {

--- a/src/api/versions/v1/schemas/registration-schemas.ts
+++ b/src/api/versions/v1/schemas/registration-schemas.ts
@@ -2,7 +2,6 @@ import { z } from "@hono/zod-openapi";
 
 export const GetRegistrationOptionsRequestSchema = z.object({
   transactionId: z
-    .string()
     .uuid()
     .describe("The transaction ID for the registration request")
     .openapi({
@@ -21,8 +20,7 @@ export type GetRegistrationOptionsRequest = z.infer<
 >;
 
 export const GetRegistrationOptionsResponseSchema = z
-  .object({})
-  .passthrough()
+  .looseObject({})
   .describe("The registration options required by the server")
   .openapi({
     example: {
@@ -71,15 +69,13 @@ export type GetRegistrationOptionsResponse = z.infer<
 
 export const VerifyRegistrationRequestSchema = z.object({
   transactionId: z
-    .string()
     .uuid()
     .describe("The transaction ID for the registration request")
     .openapi({
       example: "123e4567-e89b-12d3-a456-426614174000",
     }),
   registrationResponse: z
-    .object({})
-    .passthrough()
+    .looseObject({})
     .describe("The registration response from the authenticator"),
 });
 


### PR DESCRIPTION
## Summary
- use `z.uuid()` instead of `z.string().uuid()`
- validate IPs with `z.union([z.ipv4(), z.ipv6()])`
- replace `.object().passthrough()` with `z.looseObject()`

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687b6409ab948327b8fe7ceaea15b2c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved validation for various request and response fields, including more precise handling of UUIDs and IP addresses.
  * Enhanced flexibility for certain objects in authentication, registration, and configuration processes by allowing additional unknown keys.
  * Adjusted schema definitions to better support handling of extra properties in API responses and requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->