### PR TITLE
Fix ban duration units and add reason limits

### DIFF
--- a/src/api/versions/v1/schemas/moderation-schemas.ts
+++ b/src/api/versions/v1/schemas/moderation-schemas.ts
@@ -6,15 +6,20 @@ export const BanUserRequestSchema = z.object({
     .length(32)
     .describe("The user ID to ban")
     .openapi({ example: "123e4567e89b12d3a456426614174000" }),
-  reason: z.string().min(1).describe("Reason for the ban").openapi({
-    example: "Toxic behaviour",
-  }),
+  reason: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe("Reason for the ban")
+    .openapi({
+      example: "Toxic behaviour",
+    }),
   duration: z
     .string()
-    .regex(/^[1-9]\d*(min|h|d|w|m|y)$/)
+    .regex(/^[1-9]\d*(?:mo|m|h|d|w|y)$/)
     .optional()
     .describe(
-      "Relative ban duration. Use 'min' for minutes, 'h' for hours, 'd' for days, 'w' for weeks, 'm' for months and 'y' for years",
+      `Relative ban duration. Supported units:\n- 'm' for minutes\n- 'h' for hours\n- 'd' for days\n- 'w' for weeks\n- 'mo' for months\n- 'y' for years`,
     )
     .openapi({ example: "1h" }),
 });

--- a/src/api/versions/v1/utils/time-utils.ts
+++ b/src/api/versions/v1/utils/time-utils.ts
@@ -1,15 +1,15 @@
 export class TimeUtils {
   private static readonly unitMap: Record<string, number> = {
-    min: 60 * 1000,
+    m: 60 * 1000,
     h: 60 * 60 * 1000,
     d: 24 * 60 * 60 * 1000,
     w: 7 * 24 * 60 * 60 * 1000,
-    m: 30 * 24 * 60 * 60 * 1000,
+    mo: 30 * 24 * 60 * 60 * 1000,
     y: 365 * 24 * 60 * 60 * 1000,
   };
 
   public static parseRelativeTime(value: string): number {
-    const match = value.match(/^([1-9]\d*)(min|h|d|w|m|y)$/);
+    const match = value.match(/^([1-9]\d*)(mo|m|h|d|w|y)$/);
     if (!match) {
       throw new Error(`Invalid relative time format: ${value}`);
     }


### PR DESCRIPTION
## Summary
- rework ban duration validation with `m` for minutes and `mo` for months
- bullet point duration units in schema docs
- limit moderation reasons to 100 characters

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687ba3eb55148327a4879a1fe81b2925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for specifying ban durations with clearer and more flexible time unit options, including explicit support for "mo" (months) and "m" (minutes).
* **Improvements**
  * Enhanced validation for ban reasons by limiting the length to 100 characters.
  * Updated descriptions to clarify supported duration units for user bans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->