### PR TITLE
Refactor ban duration API

### DIFF
--- a/src/api/versions/v1/schemas/moderation-schemas.ts
+++ b/src/api/versions/v1/schemas/moderation-schemas.ts
@@ -1,28 +1,43 @@
 import { z } from "@hono/zod-openapi";
 
-export const BanUserRequestSchema = z.object({
-  userId: z
-    .string()
-    .length(32)
-    .describe("The user ID to ban")
-    .openapi({ example: "123e4567e89b12d3a456426614174000" }),
-  reason: z
-    .string()
-    .min(1)
-    .max(100)
-    .describe("Reason for the ban")
-    .openapi({
-      example: "Toxic behaviour",
-    }),
-  duration: z
-    .string()
-    .regex(/^[1-9]\d*(?:mo|m|h|d|w|y)$/)
-    .optional()
-    .describe(
-      `Relative ban duration. Supported units:\n- 'm' for minutes\n- 'h' for hours\n- 'd' for days\n- 'w' for weeks\n- 'mo' for months\n- 'y' for years`,
-    )
-    .openapi({ example: "1h" }),
-});
+export const BanUserRequestSchema = z
+  .object({
+    userId: z
+      .string()
+      .length(32)
+      .describe("The user ID to ban")
+      .openapi({ example: "123e4567e89b12d3a456426614174000" }),
+    reason: z
+      .string()
+      .min(1)
+      .max(100)
+      .describe("Reason for the ban")
+      .openapi({ example: "Toxic behaviour" }),
+    durationValue: z
+      .number()
+      .int()
+      .min(1)
+      .max(45)
+      .optional()
+      .describe("Duration value")
+      .openapi({ example: 1 }),
+    durationUnit: z
+      .enum(["minutes", "hours", "weeks", "months", "years"])
+      .optional()
+      .describe(
+        `Duration unit. Supported units:\n- 'minutes'\n- 'hours'\n- 'weeks'\n- 'months'\n- 'years'`,
+      )
+      .openapi({ example: "hours" }),
+  })
+  .refine(
+    (data) =>
+      (data.durationValue === undefined && data.durationUnit === undefined) ||
+      (data.durationValue !== undefined && data.durationUnit !== undefined),
+    {
+      message: "durationValue and durationUnit must be provided together",
+      path: ["durationValue"],
+    },
+  );
 
 export type BanUserRequest = z.infer<typeof BanUserRequestSchema>;
 

--- a/src/api/versions/v1/services/moderation-service.ts
+++ b/src/api/versions/v1/services/moderation-service.ts
@@ -10,7 +10,7 @@ export class ModerationService {
   constructor(private kvService = inject(KVService)) {}
 
   public async banUser(body: BanUserRequest): Promise<void> {
-    const { userId, reason, duration } = body;
+    const { userId, reason, durationValue, durationUnit } = body;
     const user = await this.kvService.getUser(userId);
 
     if (user === null) {
@@ -18,9 +18,9 @@ export class ModerationService {
     }
 
     let expiresAt: number | null = null;
-    if (duration) {
+    if (durationValue !== undefined && durationUnit !== undefined) {
       try {
-        expiresAt = TimeUtils.parseRelativeTime(duration);
+        expiresAt = TimeUtils.getRelativeTimestamp(durationValue, durationUnit);
       } catch {
         throw new ServerError(
           "INVALID_DURATION",

--- a/src/api/versions/v1/utils/time-utils.ts
+++ b/src/api/versions/v1/utils/time-utils.ts
@@ -1,30 +1,32 @@
+export type DurationUnit =
+  | "minutes"
+  | "hours"
+  | "weeks"
+  | "months"
+  | "years";
+
 export class TimeUtils {
-  private static readonly unitMap: Record<string, number> = {
-    m: 60 * 1000,
-    h: 60 * 60 * 1000,
-    d: 24 * 60 * 60 * 1000,
-    w: 7 * 24 * 60 * 60 * 1000,
-    mo: 30 * 24 * 60 * 60 * 1000,
-    y: 365 * 24 * 60 * 60 * 1000,
+  private static readonly unitMap: Record<DurationUnit, number> = {
+    minutes: 60 * 1000,
+    hours: 60 * 60 * 1000,
+    weeks: 7 * 24 * 60 * 60 * 1000,
+    months: 30 * 24 * 60 * 60 * 1000,
+    years: 365 * 24 * 60 * 60 * 1000,
   };
 
-  public static parseRelativeTime(value: string): number {
-    const match = value.match(/^([1-9]\d*)(mo|m|h|d|w|y)$/);
-    if (!match) {
-      throw new Error(`Invalid relative time format: ${value}`);
-    }
-
-    const amount = Number(match[1]);
-    const unit = match[2];
+  public static getRelativeTimestamp(
+    value: number,
+    unit: DurationUnit,
+  ): number {
     const multiplier = TimeUtils.unitMap[unit];
-    const relativeMs = amount * multiplier;
+    const relativeMs = value * multiplier;
     if (relativeMs > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Relative time overflow: ${value}`);
+      throw new Error(`Relative time overflow: ${value}${unit}`);
     }
 
     const timestamp = Date.now() + relativeMs;
     if (timestamp > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Relative time overflow: ${value}`);
+      throw new Error(`Relative time overflow: ${value}${unit}`);
     }
 
     return timestamp;


### PR DESCRIPTION
## Summary
- adjust ban schema to use `durationValue` and `durationUnit`
- parse new ban duration fields in moderation service
- rewrite time utils for duration unit handling

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_687ba9d572548327b833e9a349528e67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the ban user functionality to allow specifying ban duration using separate value and unit fields (e.g., 5 hours, 2 weeks), with clearer supported units and improved input validation.

* **Documentation**
  * Enhanced descriptions and examples for ban duration options to improve clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->