### PR TITLE
Implement report user feature

### DIFF
--- a/src/api/versions/v1/constants/kv-constants.ts
+++ b/src/api/versions/v1/constants/kv-constants.ts
@@ -10,5 +10,6 @@ export const KV_KEYS = "keys";
 export const KV_MESSAGE = "message";
 export const KV_MATCHES = "matches";
 export const KV_SCORES = "scores";
+export const KV_REPORT = "report";
 
 export const KV_OPTIONS_EXPIRATION_TIME = 5 * 60 * 1000;

--- a/src/api/versions/v1/interfaces/kv/report-kv.ts
+++ b/src/api/versions/v1/interfaces/kv/report-kv.ts
@@ -1,0 +1,5 @@
+export interface ReportKV {
+  userId: string;
+  reason: string;
+  automatic: boolean;
+}

--- a/src/api/versions/v1/routers/authenticated-router.ts
+++ b/src/api/versions/v1/routers/authenticated-router.ts
@@ -8,6 +8,7 @@ import { AuthenticatedMessagesRouter } from "./authenticated/authenticated-messa
 import { AuthenticatedMatchesRouter } from "./authenticated/authenticated-matches-router.ts";
 import { AuthenticatedScoresRouter } from "./authenticated/authenticated-scores-router.ts";
 import { AuthenticatedStatsRouter } from "./authenticated/authenticated-stats-router.ts";
+import { AuthenticatedUserModerationRouter } from "./authenticated/authenticated-user-moderation-router.ts";
 
 @injectable()
 export class V1AuthenticatedRouter {
@@ -21,6 +22,7 @@ export class V1AuthenticatedRouter {
     private statsRouter = inject(AuthenticatedStatsRouter),
     private matchesRouter = inject(AuthenticatedMatchesRouter),
     private scoresRouter = inject(AuthenticatedScoresRouter),
+    private userModerationRouter = inject(AuthenticatedUserModerationRouter),
   ) {
     this.app = new OpenAPIHono();
     this.setMiddlewares();
@@ -46,5 +48,6 @@ export class V1AuthenticatedRouter {
     this.app.route("/server-stats", this.statsRouter.getRouter());
     this.app.route("/matches", this.matchesRouter.getRouter());
     this.app.route("/player-scores", this.scoresRouter.getRouter());
+    this.app.route("/user-moderation", this.userModerationRouter.getRouter());
   }
 }

--- a/src/api/versions/v1/routers/authenticated/authenticated-user-moderation-router.ts
+++ b/src/api/versions/v1/routers/authenticated/authenticated-user-moderation-router.ts
@@ -1,0 +1,57 @@
+import { inject, injectable } from "@needle-di/core";
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { ModerationService } from "../../services/moderation-service.ts";
+import { HonoVariablesType } from "../../../../../core/types/hono-variables-type.ts";
+import { ReportUserRequestSchema } from "../../schemas/moderation-schemas.ts";
+import { ServerResponse } from "../../models/server-response.ts";
+
+@injectable()
+export class AuthenticatedUserModerationRouter {
+  private app: OpenAPIHono<{ Variables: HonoVariablesType }>;
+
+  constructor(private moderationService = inject(ModerationService)) {
+    this.app = new OpenAPIHono();
+    this.setRoutes();
+  }
+
+  public getRouter(): OpenAPIHono<{ Variables: HonoVariablesType }> {
+    return this.app;
+  }
+
+  private setRoutes(): void {
+    this.registerReportUserRoute();
+  }
+
+  private registerReportUserRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "post",
+        path: "/report",
+        summary: "Report user",
+        description: "Reports a user for breaking the rules",
+        tags: ["User moderation"],
+        request: {
+          body: {
+            content: {
+              "application/json": {
+                schema: ReportUserRequestSchema,
+              },
+            },
+          },
+        },
+        responses: {
+          ...ServerResponse.NoContent,
+          ...ServerResponse.BadRequest,
+          ...ServerResponse.Unauthorized,
+          ...ServerResponse.NotFound,
+        },
+      }),
+      async (c) => {
+        const reporterId = c.get("userId");
+        const validated = c.req.valid("json");
+        await this.moderationService.reportUser(reporterId, validated);
+        return c.body(null, 204);
+      },
+    );
+  }
+}

--- a/src/api/versions/v1/schemas/moderation-schemas.ts
+++ b/src/api/versions/v1/schemas/moderation-schemas.ts
@@ -35,3 +35,25 @@ export const UnbanUserRequestSchema = z.object({
 });
 
 export type UnbanUserRequest = z.infer<typeof UnbanUserRequestSchema>;
+
+export const ReportUserRequestSchema = z.object({
+  userId: z
+    .string()
+    .length(32)
+    .describe("The user ID to report")
+    .openapi({ example: "123e4567e89b12d3a456426614174000" }),
+  reason: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe("Reason for the report")
+    .openapi({ example: "Offensive language" }),
+  automatic: z
+    .boolean()
+    .describe(
+      "Defines if the game client reported this automatically",
+    )
+    .openapi({ example: false }),
+});
+
+export type ReportUserRequest = z.infer<typeof ReportUserRequestSchema>;

--- a/src/api/versions/v1/services/moderation-service.ts
+++ b/src/api/versions/v1/services/moderation-service.ts
@@ -2,7 +2,11 @@ import { inject, injectable } from "@needle-di/core";
 import { KVService } from "../../../../core/services/kv-service.ts";
 import { ServerError } from "../models/server-error.ts";
 import { BanInformation } from "../interfaces/kv/user-kv.ts";
-import { BanUserRequest } from "../schemas/moderation-schemas.ts";
+import {
+  BanUserRequest,
+  ReportUserRequest,
+} from "../schemas/moderation-schemas.ts";
+import { ReportKV } from "../interfaces/kv/report-kv.ts";
 import { TimeUtils } from "../utils/time-utils.ts";
 
 @injectable()
@@ -51,5 +55,20 @@ export class ModerationService {
       user.ban = undefined;
       await this.kvService.setUser(userId, user);
     }
+  }
+
+  public async reportUser(
+    reporterId: string,
+    body: ReportUserRequest,
+  ): Promise<void> {
+    const { userId, reason, automatic } = body;
+    const user = await this.kvService.getUser(userId);
+
+    if (user === null) {
+      throw new ServerError("USER_NOT_FOUND", "User not found", 404);
+    }
+
+    const report: ReportKV = { userId, reason, automatic };
+    await this.kvService.setReport(reporterId, userId, report);
   }
 }

--- a/src/core/services/kv-service.ts
+++ b/src/core/services/kv-service.ts
@@ -7,6 +7,7 @@ import {
   KV_MESSAGE,
   KV_REGISTRATION_OPTIONS,
   KV_SCORES,
+  KV_REPORT,
   KV_SESSIONS,
   KV_USERS,
   KV_USERS_BY_DISPLAY_NAME,
@@ -22,6 +23,7 @@ import { SessionKV } from "../../api/versions/v1/interfaces/kv/session-kv.ts";
 import { MessageKV } from "../../api/versions/v1/interfaces/kv/message-kv.ts";
 import { MatchKV } from "../../api/versions/v1/interfaces/kv/match_kv.ts";
 import { ScoreKV } from "../../api/versions/v1/interfaces/kv/score.ts";
+import { ReportKV } from "../../api/versions/v1/interfaces/kv/report-kv.ts";
 import { ConfigurationType } from "../types/configuration-type.ts";
 
 @injectable()
@@ -219,6 +221,17 @@ export class KVService {
 
   public async deleteMessage(timestamp: number): Promise<void> {
     await this.getKv().delete([KV_MESSAGE, timestamp]);
+  }
+
+  public async setReport(
+    reporterId: string,
+    reportedUserId: string,
+    report: ReportKV,
+  ): Promise<void> {
+    await this.getKv().set(
+      [KV_REPORT, reporterId, reportedUserId, Date.now()],
+      report,
+    );
   }
 
   public listMatches(): Deno.KvListIterator<MatchKV> {


### PR DESCRIPTION
## Summary
- add KV constant for reports
- define `ReportUserRequest` schema
- implement report user logic in moderation service & kv service
- create authenticated user moderation router and wire it up

## Testing
- `deno check src/main.ts` *(fails: JSR package manifest for '@needle-di/core' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_687baaa87a0c8327ab18d1f0f32d6ba3