### PR TITLE
Update ban duration validation

### DIFF
--- a/src/api/versions/v1/schemas/moderation-schemas.ts
+++ b/src/api/versions/v1/schemas/moderation-schemas.ts
@@ -19,7 +19,7 @@ export const BanDurationSchema = z
       case "minutes":
         return d.value <= 59;
       case "hours":
-        return d.value <= 24;
+        return d.value <= 23;
       case "days":
         return d.value <= 7;
       case "weeks":

--- a/src/api/versions/v1/services/moderation-service.ts
+++ b/src/api/versions/v1/services/moderation-service.ts
@@ -24,7 +24,7 @@ export class ModerationService {
     let expiresAt: number | null = null;
     if (duration) {
       try {
-        expiresAt = TimeUtils.parseRelativeTime(duration);
+        expiresAt = TimeUtils.parseDuration(duration);
       } catch {
         throw new ServerError(
           "INVALID_DURATION",

--- a/src/api/versions/v1/utils/time-utils.ts
+++ b/src/api/versions/v1/utils/time-utils.ts
@@ -17,6 +17,19 @@ export class TimeUtils {
     years: 365 * 24 * 60 * 60 * 1000,
   };
 
+  private static addRelativeMs(relativeMs: number, descriptor: string): number {
+    if (relativeMs > Number.MAX_SAFE_INTEGER) {
+      throw new Error(`Relative time overflow: ${descriptor}`);
+    }
+
+    const timestamp = Date.now() + relativeMs;
+    if (timestamp > Number.MAX_SAFE_INTEGER) {
+      throw new Error(`Relative time overflow: ${descriptor}`);
+    }
+
+    return timestamp;
+  }
+
   public static parseRelativeTime(value: string): number {
     const match = value.match(/^([1-9]\d*)(mo|m|h|d|w|y)$/);
     if (!match) {
@@ -27,16 +40,7 @@ export class TimeUtils {
     const unit = match[2];
     const multiplier = TimeUtils.unitMap[unit];
     const relativeMs = amount * multiplier;
-    if (relativeMs > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Relative time overflow: ${value}`);
-    }
-
-    const timestamp = Date.now() + relativeMs;
-    if (timestamp > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Relative time overflow: ${value}`);
-    }
-
-    return timestamp;
+    return TimeUtils.addRelativeMs(relativeMs, value);
   }
 
   public static parseDuration(
@@ -48,19 +52,9 @@ export class TimeUtils {
     }
 
     const relativeMs = duration.value * multiplier;
-    if (relativeMs > Number.MAX_SAFE_INTEGER) {
-      throw new Error(
-        `Relative time overflow: ${duration.value}${duration.unit}`,
-      );
-    }
-
-    const timestamp = Date.now() + relativeMs;
-    if (timestamp > Number.MAX_SAFE_INTEGER) {
-      throw new Error(
-        `Relative time overflow: ${duration.value}${duration.unit}`,
-      );
-    }
-
-    return timestamp;
+    return TimeUtils.addRelativeMs(
+      relativeMs,
+      `${duration.value}${duration.unit}`,
+    );
   }
 }

--- a/src/api/versions/v1/utils/time-utils.ts
+++ b/src/api/versions/v1/utils/time-utils.ts
@@ -8,6 +8,15 @@ export class TimeUtils {
     y: 365 * 24 * 60 * 60 * 1000,
   };
 
+  private static readonly objectUnitMap: Record<string, number> = {
+    minutes: 60 * 1000,
+    hours: 60 * 60 * 1000,
+    days: 24 * 60 * 60 * 1000,
+    weeks: 7 * 24 * 60 * 60 * 1000,
+    months: 30 * 24 * 60 * 60 * 1000,
+    years: 365 * 24 * 60 * 60 * 1000,
+  };
+
   public static parseRelativeTime(value: string): number {
     const match = value.match(/^([1-9]\d*)(mo|m|h|d|w|y)$/);
     if (!match) {
@@ -25,6 +34,31 @@ export class TimeUtils {
     const timestamp = Date.now() + relativeMs;
     if (timestamp > Number.MAX_SAFE_INTEGER) {
       throw new Error(`Relative time overflow: ${value}`);
+    }
+
+    return timestamp;
+  }
+
+  public static parseDuration(
+    duration: { value: number; unit: string },
+  ): number {
+    const multiplier = TimeUtils.objectUnitMap[duration.unit];
+    if (!multiplier) {
+      throw new Error(`Invalid duration unit: ${duration.unit}`);
+    }
+
+    const relativeMs = duration.value * multiplier;
+    if (relativeMs > Number.MAX_SAFE_INTEGER) {
+      throw new Error(
+        `Relative time overflow: ${duration.value}${duration.unit}`,
+      );
+    }
+
+    const timestamp = Date.now() + relativeMs;
+    if (timestamp > Number.MAX_SAFE_INTEGER) {
+      throw new Error(
+        `Relative time overflow: ${duration.value}${duration.unit}`,
+      );
     }
 
     return timestamp;


### PR DESCRIPTION
## Summary
- validate ban duration with new `BanDurationSchema`
- convert duration object to timestamp in `ModerationService`
- add `parseDuration` helper in `TimeUtils`

## Testing
- `deno fmt src/api/versions/v1/schemas/moderation-schemas.ts src/api/versions/v1/utils/time-utils.ts src/api/versions/v1/services/moderation-service.ts`
- `deno check src/main.ts` *(fails: JSR package manifest failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_687bb18006288327b68e4d904c9b5dee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated ban duration input to use a structured format with selectable time units (minutes, hours, days, weeks, months, years) and value limits for each unit.
  * Users can now specify ban durations more precisely, or leave duration blank for a permanent ban.

* **Bug Fixes**
  * Improved validation for ban duration to prevent invalid or excessive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->