### PR TITLE
fix: atomically consume registration options

### DIFF
--- a/src/api/versions/v1/services/kv-service.ts
+++ b/src/api/versions/v1/services/kv-service.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "@needle-di/core";
 import { BaseKVService } from "../../../../core/services/kv-service.ts";
 import {
-  KV_VERSION,
-  KV_REGISTRATION_OPTIONS,
   KV_AUTHENTICATION_OPTIONS,
   KV_CONFIGURATION,
-  KV_USER_KEYS,
+  KV_REGISTRATION_OPTIONS,
   KV_SIGNATURE_KEYS,
+  KV_USER_KEYS,
+  KV_VERSION,
 } from "../constants/kv-constants.ts";
 import { AuthenticationOptionsKV } from "../interfaces/kv/authentication-options-kv.ts";
 import { RegistrationOptionsKV } from "../interfaces/kv/registration-options-kv.ts";
@@ -19,8 +19,9 @@ export class KVService {
   constructor(private kvService = inject(BaseKVService)) {}
 
   public async getSignatureKeys(): Promise<SignatureKeysKV | null> {
-    const entry: Deno.KvEntryMaybe<SignatureKeysKV> =
-      await this.getKv().get<SignatureKeysKV>([KV_SIGNATURE_KEYS]);
+    const entry: Deno.KvEntryMaybe<SignatureKeysKV> = await this.getKv().get<
+      SignatureKeysKV
+    >([KV_SIGNATURE_KEYS]);
 
     return entry.value;
   }
@@ -30,8 +31,9 @@ export class KVService {
   }
 
   public async getVersion(): Promise<VersionKV | null> {
-    const entry: Deno.KvEntryMaybe<VersionKV> =
-      await this.getKv().get<VersionKV>([KV_VERSION]);
+    const entry: Deno.KvEntryMaybe<VersionKV> = await this.getKv().get<
+      VersionKV
+    >([KV_VERSION]);
 
     return entry.value;
   }
@@ -41,10 +43,10 @@ export class KVService {
   }
 
   public async getRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<RegistrationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> =
-      await this.getKv().get<RegistrationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> = await this.getKv()
+      .get<RegistrationOptionsKV>([
         KV_REGISTRATION_OPTIONS,
         transactionId,
       ]);
@@ -52,30 +54,52 @@ export class KVService {
     return entry.value;
   }
 
+  public async consumeRegistrationOptionsByTransactionId(
+    transactionId: string,
+  ): Promise<RegistrationOptionsKV | null> {
+    const key = [KV_REGISTRATION_OPTIONS, transactionId];
+    const kv = this.getKv();
+    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> = await kv.get<
+      RegistrationOptionsKV
+    >(key);
+
+    if (entry.value === null) {
+      return null;
+    }
+
+    const commit = await kv.atomic().check(entry).delete(key).commit();
+
+    if (!commit.ok) {
+      return null;
+    }
+
+    return entry.value;
+  }
+
   public async setRegistrationOptions(
     transactionId: string,
-    registrationOptions: RegistrationOptionsKV
+    registrationOptions: RegistrationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_REGISTRATION_OPTIONS, transactionId],
       registrationOptions,
       {
         expireIn: 60 * 1_000,
-      }
+      },
     );
   }
 
   public async deleteRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_REGISTRATION_OPTIONS, transactionId]);
   }
 
   public async getAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<AuthenticationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> =
-      await this.getKv().get<AuthenticationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> = await this.getKv()
+      .get<AuthenticationOptionsKV>([
         KV_AUTHENTICATION_OPTIONS,
         transactionId,
       ]);
@@ -85,32 +109,33 @@ export class KVService {
 
   public async setAuthenticationOptions(
     requestId: string,
-    authenticationOptions: AuthenticationOptionsKV
+    authenticationOptions: AuthenticationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_AUTHENTICATION_OPTIONS, requestId],
       authenticationOptions,
       {
         expireIn: 60 * 1_000,
-      }
+      },
     );
   }
 
   public async deleteAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_AUTHENTICATION_OPTIONS, transactionId]);
   }
 
   public async getConfiguration(): Promise<ConfigurationType | null> {
-    const entry: Deno.KvEntryMaybe<ConfigurationType> =
-      await this.getKv().get<ConfigurationType>([KV_CONFIGURATION]);
+    const entry: Deno.KvEntryMaybe<ConfigurationType> = await this.getKv().get<
+      ConfigurationType
+    >([KV_CONFIGURATION]);
 
     return entry.value;
   }
 
   public async setConfiguration(
-    configuration: ConfigurationType
+    configuration: ConfigurationType,
   ): Promise<void> {
     await this.getKv().set([KV_CONFIGURATION], configuration);
   }
@@ -131,7 +156,7 @@ export class KVService {
   }
 
   public async deleteUserTemporaryData(
-    userId: string
+    userId: string,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     return await this.getKv().atomic().delete([KV_USER_KEYS, userId]).commit();
   }

--- a/src/api/versions/v1/services/registration-service.ts
+++ b/src/api/versions/v1/services/registration-service.ts
@@ -18,7 +18,7 @@ import {
 } from "../schemas/registration-schemas.ts";
 import { KV_OPTIONS_EXPIRATION_TIME } from "../constants/kv-constants.ts";
 import { Base64Utils } from "../../../../core/utils/base64-utils.ts";
-import { usersTable, userCredentialsTable } from "../../../../db/schema.ts";
+import { userCredentialsTable, usersTable } from "../../../../db/schema.ts";
 import { eq } from "drizzle-orm";
 import { UserCredentialEntity } from "../../../../db/tables/user-credentials-table.ts";
 import { UserEntity } from "../../../../db/tables/users-table.ts";
@@ -29,11 +29,11 @@ export class RegistrationService {
   constructor(
     private kvService = inject(KVService),
     private databaseService = inject(DatabaseService),
-    private authenticationService = inject(AuthenticationService)
+    private authenticationService = inject(AuthenticationService),
   ) {}
 
   public async getOptions(
-    registrationOptionsRequest: GetRegistrationOptionsRequest
+    registrationOptionsRequest: GetRegistrationOptionsRequest,
   ): Promise<object> {
     const { transactionId, displayName } = registrationOptionsRequest;
     console.log("Registration options for display name", displayName);
@@ -64,23 +64,19 @@ export class RegistrationService {
 
   public async verifyResponse(
     connectionInfo: ConnInfo,
-    registrationRequest: VerifyRegistrationRequest
+    registrationRequest: VerifyRegistrationRequest,
   ): Promise<AuthenticationResponse> {
     const { transactionId } = registrationRequest;
-    const registrationOptions = await this.getRegistrationOptionsOrThrow(
-      transactionId
+    const registrationOptions = await this.consumeRegistrationOptionsOrThrow(
+      transactionId,
     );
 
-    await this.kvService.deleteRegistrationOptionsByTransactionId(
-      transactionId
-    );
-
-    const registrationResponse =
-      registrationRequest.registrationResponse as object as RegistrationResponseJSON;
+    const registrationResponse = registrationRequest
+      .registrationResponse as object as RegistrationResponseJSON;
 
     const verification = await this.verifyRegistrationResponse(
       registrationResponse,
-      registrationOptions
+      registrationOptions,
     );
 
     const credential = this.createCredential(registrationOptions, verification);
@@ -103,33 +99,35 @@ export class RegistrationService {
       throw new ServerError(
         "DISPLAY_NAME_TAKEN",
         "Display name is already taken",
-        409
+        409,
       );
     }
   }
 
-  private async getRegistrationOptionsOrThrow(
-    transactionId: string
+  private async consumeRegistrationOptionsOrThrow(
+    transactionId: string,
   ): Promise<PublicKeyCredentialCreationOptionsJSON> {
-    const registrationOptions =
-      await this.kvService.getRegistrationOptionsByTransactionId(transactionId);
+    const registrationOptions = await this.kvService
+      .consumeRegistrationOptionsByTransactionId(
+        transactionId,
+      );
 
     if (registrationOptions === null) {
       throw new ServerError(
         "REGISTRATION_OPTIONS_NOT_FOUND",
         "Registration options not found",
-        400
+        400,
       );
     }
 
     if (
       registrationOptions.createdAt + KV_OPTIONS_EXPIRATION_TIME <
-      Date.now()
+        Date.now()
     ) {
       throw new ServerError(
         "REGISTRATION_OPTIONS_EXPIRED",
         "Registration options expired",
-        400
+        400,
       );
     }
 
@@ -138,7 +136,7 @@ export class RegistrationService {
 
   private async verifyRegistrationResponse(
     registrationResponse: RegistrationResponseJSON,
-    registrationOptions: PublicKeyCredentialCreationOptionsJSON
+    registrationOptions: PublicKeyCredentialCreationOptionsJSON,
   ): Promise<VerifiedRegistrationResponse> {
     try {
       const verification = await verifyRegistrationResponse({
@@ -162,14 +160,14 @@ export class RegistrationService {
       throw new ServerError(
         "REGISTRATION_VERIFICATION_FAILED",
         "Registration verification failed",
-        400
+        400,
       );
     }
   }
 
   private createCredential(
     registrationOptions: PublicKeyCredentialCreationOptionsJSON,
-    verification: VerifiedRegistrationResponse
+    verification: VerifiedRegistrationResponse,
   ): UserCredentialEntity {
     const { registrationInfo } = verification;
 
@@ -179,7 +177,7 @@ export class RegistrationService {
 
     const userId = Base64Utils.base64UrlToString(registrationOptions.user.id);
     const publicKey = Base64Utils.arrayBufferToBase64Url(
-      registrationInfo.credential.publicKey.buffer
+      registrationInfo.credential.publicKey.buffer,
     );
 
     return {
@@ -195,7 +193,7 @@ export class RegistrationService {
 
   private createUser(
     credential: UserCredentialEntity,
-    registrationOptions: PublicKeyCredentialCreationOptionsJSON
+    registrationOptions: PublicKeyCredentialCreationOptionsJSON,
   ): UserEntity {
     const { userId } = credential;
 
@@ -208,7 +206,7 @@ export class RegistrationService {
 
   private async addCredentialAndUserOrThrow(
     credential: UserCredentialEntity,
-    user: UserEntity
+    user: UserEntity,
   ): Promise<void> {
     const db = this.databaseService.get();
 
@@ -237,7 +235,7 @@ export class RegistrationService {
       throw new ServerError(
         "CREDENTIAL_USER_ADD_FAILED",
         "Failed to add credential and user",
-        500
+        500,
       );
     }
   }


### PR DESCRIPTION
## Summary
- atomically consume registration options from Deno KV to prevent replay attacks
- use consumed options during WebAuthn verification

## Testing
- `deno fmt src/api/versions/v1/services/kv-service.ts src/api/versions/v1/services/registration-service.ts`
- `deno check src/main.ts` *(fails: JSR package manifest for '@needle-di/core' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81d12e008327b72c1974694802be