### PR TITLE
feat: atomically consume auth options

### DIFF
--- a/src/api/versions/v1/services/authentication-service.ts
+++ b/src/api/versions/v1/services/authentication-service.ts
@@ -23,13 +23,13 @@ import {
 } from "../schemas/authentication-schemas.ts";
 import { KV_OPTIONS_EXPIRATION_TIME } from "../constants/kv-constants.ts";
 import {
-  usersTable,
-  userCredentialsTable,
-  userBansTable,
-  userRolesTable,
   rolesTable,
+  userBansTable,
+  userCredentialsTable,
+  userRolesTable,
+  usersTable,
 } from "../../../../db/schema.ts";
-import { eq, and, lt } from "drizzle-orm";
+import { and, eq, lt } from "drizzle-orm";
 import { UserCredentialEntity } from "../../../../db/tables/user-credentials-table.ts";
 import { UserEntity } from "../../../../db/tables/users-table.ts";
 import { desc } from "drizzle-orm";
@@ -43,11 +43,11 @@ export class AuthenticationService {
     private databaseService = inject(DatabaseService),
     private jwtService = inject(JWTService),
     private signatureService = inject(SignatureService),
-    private iceService = inject(ICEService)
+    private iceService = inject(ICEService),
   ) {}
 
   public async getOptions(
-    authenticationRequest: GetAuthenticationOptionsRequest
+    authenticationRequest: GetAuthenticationOptionsRequest,
   ): Promise<object> {
     const { transactionId } = authenticationRequest;
     const options = await generateAuthenticationOptions({
@@ -65,28 +65,24 @@ export class AuthenticationService {
 
   public async verifyResponse(
     connectionInfo: ConnInfo,
-    authenticationRequest: VerifyAuthenticationRequest
+    authenticationRequest: VerifyAuthenticationRequest,
   ): Promise<AuthenticationResponse> {
     const { transactionId } = authenticationRequest;
-    const authenticationResponse =
-      authenticationRequest.authenticationResponse as object as AuthenticationResponseJSON;
+    const authenticationResponse = authenticationRequest
+      .authenticationResponse as object as AuthenticationResponseJSON;
 
     const authenticationOptions = await this.getAuthenticationOptionsOrThrow(
-      transactionId
-    );
-
-    await this.kvService.deleteAuthenticationOptionsByTransactionId(
-      transactionId
+      transactionId,
     );
 
     const credential = await this.getCredentialOrThrow(
-      authenticationResponse.id
+      authenticationResponse.id,
     );
 
     const verification = await this.verifyAuthenticationResponse(
       authenticationResponse,
       authenticationOptions,
-      credential
+      credential,
     );
 
     await this.updateCredentialCounter(credential, verification);
@@ -98,7 +94,7 @@ export class AuthenticationService {
 
   public async getResponseForUser(
     connectionInfo: ConnInfo,
-    user: UserEntity
+    user: UserEntity,
   ): Promise<AuthenticationResponse> {
     await this.ensureUserNotBanned(user);
 
@@ -115,19 +111,19 @@ export class AuthenticationService {
     const authenticationToken = await create(
       { alg: "HS512", typ: "JWT" },
       { id: userId, name: userDisplayName, roles: userRoles },
-      jwtKey
+      jwtKey,
     );
 
     // Add user symmetric key for encryption/decryption
     const userSymmetricKey: string = encodeBase64(
-      crypto.getRandomValues(new Uint8Array(32)).buffer
+      crypto.getRandomValues(new Uint8Array(32)).buffer,
     );
 
     await this.kvService.setUserKey(userId, userSymmetricKey);
 
     // Server configuration
-    const serverSignaturePublicKey =
-      this.signatureService.getEncodedPublicKey();
+    const serverSignaturePublicKey = this.signatureService
+      .getEncodedPublicKey();
     const rtcIceServers = await this.iceService.getServers();
 
     const response: AuthenticationResponse = {
@@ -144,18 +140,18 @@ export class AuthenticationService {
   }
 
   private async getAuthenticationOptionsOrThrow(
-    transactionId: string
+    transactionId: string,
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    const authenticationOptions =
-      await this.kvService.getAuthenticationOptionsByTransactionId(
-        transactionId
+    const authenticationOptions = await this.kvService
+      .takeAuthenticationOptionsByTransactionId(
+        transactionId,
       );
 
     if (authenticationOptions === null) {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_NOT_FOUND",
         "Authentication options not found",
-        400
+        400,
       );
     }
 
@@ -166,7 +162,7 @@ export class AuthenticationService {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_EXPIRED",
         "Authentication options expired",
-        400
+        400,
       );
     }
 
@@ -174,7 +170,7 @@ export class AuthenticationService {
   }
 
   private async getCredentialOrThrow(
-    id: string
+    id: string,
   ): Promise<UserCredentialEntity> {
     let credentials;
 
@@ -191,7 +187,7 @@ export class AuthenticationService {
       throw new ServerError(
         "DATABASE_ERROR",
         "Failed to retrieve credential",
-        500
+        500,
       );
     }
 
@@ -199,7 +195,7 @@ export class AuthenticationService {
       throw new ServerError(
         "CREDENTIAL_NOT_FOUND",
         "Credential not found",
-        400
+        400,
       );
     }
 
@@ -209,7 +205,7 @@ export class AuthenticationService {
   private transformCredentialForWebAuthn(credential: UserCredentialEntity) {
     // Convert base64 string back to Uint8Array for WebAuthn usage
     const publicKeyBuffer = new Uint8Array(
-      Base64Utils.base64UrlToArrayBuffer(credential.publicKey)
+      Base64Utils.base64UrlToArrayBuffer(credential.publicKey),
     );
 
     return {
@@ -225,7 +221,7 @@ export class AuthenticationService {
   private async verifyAuthenticationResponse(
     authenticationResponse: AuthenticationResponseJSON,
     authenticationOptions: PublicKeyCredentialRequestOptionsJSON,
-    credential: UserCredentialEntity
+    credential: UserCredentialEntity,
   ): Promise<VerifiedAuthenticationResponse> {
     try {
       const verification = await verifyAuthenticationResponse({
@@ -240,7 +236,7 @@ export class AuthenticationService {
         throw new ServerError(
           "AUTHENTICATION_FAILED",
           "Authentication failed",
-          400
+          400,
         );
       }
 
@@ -250,14 +246,14 @@ export class AuthenticationService {
       throw new ServerError(
         "AUTHENTICATION_FAILED",
         "Authentication failed",
-        400
+        400,
       );
     }
   }
 
   private async updateCredentialCounter(
     credential: UserCredentialEntity,
-    verification: VerifiedAuthenticationResponse
+    verification: VerifiedAuthenticationResponse,
   ): Promise<void> {
     const { authenticationInfo } = verification;
     const newCounter = authenticationInfo.newCounter;
@@ -270,8 +266,8 @@ export class AuthenticationService {
           .where(
             and(
               eq(userCredentialsTable.id, credential.id),
-              lt(userCredentialsTable.counter, newCounter)
-            )
+              lt(userCredentialsTable.counter, newCounter),
+            ),
           );
       });
     } catch (error) {
@@ -279,13 +275,13 @@ export class AuthenticationService {
       throw new ServerError(
         "CREDENTIAL_COUNTER_UPDATE_FAILED",
         "Failed to update credential counter",
-        500
+        500,
       );
     }
   }
 
   private async getUserOrThrowError(
-    credential: UserCredentialEntity
+    credential: UserCredentialEntity,
   ): Promise<UserEntity> {
     const userId = credential.userId;
     let users;
@@ -328,7 +324,7 @@ export class AuthenticationService {
       throw new ServerError(
         "DATABASE_ERROR",
         "Failed to retrieve user roles",
-        500
+        500,
       );
     }
 
@@ -352,7 +348,7 @@ export class AuthenticationService {
       throw new ServerError(
         "DATABASE_ERROR",
         "Failed to retrieve user bans",
-        500
+        500,
       );
     }
 
@@ -368,7 +364,7 @@ export class AuthenticationService {
       throw new ServerError(
         "USER_BANNED_PERMANENTLY",
         "Your account has been permanently banned",
-        403
+        403,
       );
     }
 
@@ -387,7 +383,7 @@ export class AuthenticationService {
       throw new ServerError(
         "USER_BANNED_TEMPORARILY",
         `Your account is temporarily banned. The ban will expire on ${formattedDate}`,
-        403
+        403,
       );
     }
   }

--- a/src/api/versions/v1/services/kv-service.ts
+++ b/src/api/versions/v1/services/kv-service.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "@needle-di/core";
 import { BaseKVService } from "../../../../core/services/kv-service.ts";
 import {
-  KV_VERSION,
-  KV_REGISTRATION_OPTIONS,
   KV_AUTHENTICATION_OPTIONS,
   KV_CONFIGURATION,
-  KV_USER_KEYS,
+  KV_REGISTRATION_OPTIONS,
   KV_SIGNATURE_KEYS,
+  KV_USER_KEYS,
+  KV_VERSION,
 } from "../constants/kv-constants.ts";
 import { AuthenticationOptionsKV } from "../interfaces/kv/authentication-options-kv.ts";
 import { RegistrationOptionsKV } from "../interfaces/kv/registration-options-kv.ts";
@@ -19,8 +19,9 @@ export class KVService {
   constructor(private kvService = inject(BaseKVService)) {}
 
   public async getSignatureKeys(): Promise<SignatureKeysKV | null> {
-    const entry: Deno.KvEntryMaybe<SignatureKeysKV> =
-      await this.getKv().get<SignatureKeysKV>([KV_SIGNATURE_KEYS]);
+    const entry: Deno.KvEntryMaybe<SignatureKeysKV> = await this.getKv().get<
+      SignatureKeysKV
+    >([KV_SIGNATURE_KEYS]);
 
     return entry.value;
   }
@@ -30,8 +31,9 @@ export class KVService {
   }
 
   public async getVersion(): Promise<VersionKV | null> {
-    const entry: Deno.KvEntryMaybe<VersionKV> =
-      await this.getKv().get<VersionKV>([KV_VERSION]);
+    const entry: Deno.KvEntryMaybe<VersionKV> = await this.getKv().get<
+      VersionKV
+    >([KV_VERSION]);
 
     return entry.value;
   }
@@ -41,10 +43,10 @@ export class KVService {
   }
 
   public async getRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<RegistrationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> =
-      await this.getKv().get<RegistrationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> = await this.getKv()
+      .get<RegistrationOptionsKV>([
         KV_REGISTRATION_OPTIONS,
         transactionId,
       ]);
@@ -54,28 +56,28 @@ export class KVService {
 
   public async setRegistrationOptions(
     transactionId: string,
-    registrationOptions: RegistrationOptionsKV
+    registrationOptions: RegistrationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_REGISTRATION_OPTIONS, transactionId],
       registrationOptions,
       {
         expireIn: 60 * 1_000,
-      }
+      },
     );
   }
 
   public async deleteRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_REGISTRATION_OPTIONS, transactionId]);
   }
 
   public async getAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<AuthenticationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> =
-      await this.getKv().get<AuthenticationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> = await this.getKv()
+      .get<AuthenticationOptionsKV>([
         KV_AUTHENTICATION_OPTIONS,
         transactionId,
       ]);
@@ -83,34 +85,56 @@ export class KVService {
     return entry.value;
   }
 
+  public async takeAuthenticationOptionsByTransactionId(
+    transactionId: string,
+  ): Promise<AuthenticationOptionsKV | null> {
+    const key = [KV_AUTHENTICATION_OPTIONS, transactionId];
+    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> = await this.getKv()
+      .get<AuthenticationOptionsKV>(key);
+
+    if (entry.value === null) {
+      return null;
+    }
+
+    const result = await this.getKv().atomic().check(entry).delete(key)
+      .commit();
+
+    if (!result.ok) {
+      return null;
+    }
+
+    return entry.value;
+  }
+
   public async setAuthenticationOptions(
     requestId: string,
-    authenticationOptions: AuthenticationOptionsKV
+    authenticationOptions: AuthenticationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_AUTHENTICATION_OPTIONS, requestId],
       authenticationOptions,
       {
         expireIn: 60 * 1_000,
-      }
+      },
     );
   }
 
   public async deleteAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_AUTHENTICATION_OPTIONS, transactionId]);
   }
 
   public async getConfiguration(): Promise<ConfigurationType | null> {
-    const entry: Deno.KvEntryMaybe<ConfigurationType> =
-      await this.getKv().get<ConfigurationType>([KV_CONFIGURATION]);
+    const entry: Deno.KvEntryMaybe<ConfigurationType> = await this.getKv().get<
+      ConfigurationType
+    >([KV_CONFIGURATION]);
 
     return entry.value;
   }
 
   public async setConfiguration(
-    configuration: ConfigurationType
+    configuration: ConfigurationType,
   ): Promise<void> {
     await this.getKv().set([KV_CONFIGURATION], configuration);
   }
@@ -131,7 +155,7 @@ export class KVService {
   }
 
   public async deleteUserTemporaryData(
-    userId: string
+    userId: string,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     return await this.getKv().atomic().delete([KV_USER_KEYS, userId]).commit();
   }


### PR DESCRIPTION
## Summary
- atomically retrieve and delete authentication options to avoid reuse
- streamline authentication flow by consuming options in a single KV call

## Testing
- `/root/.deno/bin/deno fmt src/api/versions/v1/services/authentication-service.ts src/api/versions/v1/services/kv-service.ts`
- `/root/.deno/bin/deno task check` *(fails: Failed caching npm package '@peculiar/asn1-x509@2.3.15': client error (Connect): invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81efdfe08327bfd33694c983f320