### PR TITLE
Align KV option expiry with validation window

### DIFF
--- a/src/api/versions/v1/constants/kv-constants.ts
+++ b/src/api/versions/v1/constants/kv-constants.ts
@@ -5,4 +5,4 @@ export const KV_AUTHENTICATION_OPTIONS = "authentication_options";
 export const KV_CONFIGURATION = "configuration";
 export const KV_USER_KEYS = "user_keys";
 
-export const KV_OPTIONS_EXPIRATION_TIME = 5 * 60 * 1000;
+export const KV_OPTIONS_EXPIRATION_TIME = 1 * 60 * 1000;

--- a/src/api/versions/v1/services/kv-service.ts
+++ b/src/api/versions/v1/services/kv-service.ts
@@ -1,12 +1,13 @@
 import { inject, injectable } from "@needle-di/core";
 import { BaseKVService } from "../../../../core/services/kv-service.ts";
 import {
-  KV_VERSION,
-  KV_REGISTRATION_OPTIONS,
   KV_AUTHENTICATION_OPTIONS,
   KV_CONFIGURATION,
-  KV_USER_KEYS,
+  KV_OPTIONS_EXPIRATION_TIME,
+  KV_REGISTRATION_OPTIONS,
   KV_SIGNATURE_KEYS,
+  KV_USER_KEYS,
+  KV_VERSION,
 } from "../constants/kv-constants.ts";
 import { AuthenticationOptionsKV } from "../interfaces/kv/authentication-options-kv.ts";
 import { RegistrationOptionsKV } from "../interfaces/kv/registration-options-kv.ts";
@@ -19,8 +20,9 @@ export class KVService {
   constructor(private kvService = inject(BaseKVService)) {}
 
   public async getSignatureKeys(): Promise<SignatureKeysKV | null> {
-    const entry: Deno.KvEntryMaybe<SignatureKeysKV> =
-      await this.getKv().get<SignatureKeysKV>([KV_SIGNATURE_KEYS]);
+    const entry: Deno.KvEntryMaybe<SignatureKeysKV> = await this.getKv().get<
+      SignatureKeysKV
+    >([KV_SIGNATURE_KEYS]);
 
     return entry.value;
   }
@@ -30,8 +32,9 @@ export class KVService {
   }
 
   public async getVersion(): Promise<VersionKV | null> {
-    const entry: Deno.KvEntryMaybe<VersionKV> =
-      await this.getKv().get<VersionKV>([KV_VERSION]);
+    const entry: Deno.KvEntryMaybe<VersionKV> = await this.getKv().get<
+      VersionKV
+    >([KV_VERSION]);
 
     return entry.value;
   }
@@ -41,10 +44,10 @@ export class KVService {
   }
 
   public async getRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<RegistrationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> =
-      await this.getKv().get<RegistrationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<RegistrationOptionsKV> = await this.getKv()
+      .get<RegistrationOptionsKV>([
         KV_REGISTRATION_OPTIONS,
         transactionId,
       ]);
@@ -54,28 +57,28 @@ export class KVService {
 
   public async setRegistrationOptions(
     transactionId: string,
-    registrationOptions: RegistrationOptionsKV
+    registrationOptions: RegistrationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_REGISTRATION_OPTIONS, transactionId],
       registrationOptions,
       {
-        expireIn: 60 * 1_000,
-      }
+        expireIn: KV_OPTIONS_EXPIRATION_TIME,
+      },
     );
   }
 
   public async deleteRegistrationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_REGISTRATION_OPTIONS, transactionId]);
   }
 
   public async getAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<AuthenticationOptionsKV | null> {
-    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> =
-      await this.getKv().get<AuthenticationOptionsKV>([
+    const entry: Deno.KvEntryMaybe<AuthenticationOptionsKV> = await this.getKv()
+      .get<AuthenticationOptionsKV>([
         KV_AUTHENTICATION_OPTIONS,
         transactionId,
       ]);
@@ -85,32 +88,33 @@ export class KVService {
 
   public async setAuthenticationOptions(
     requestId: string,
-    authenticationOptions: AuthenticationOptionsKV
+    authenticationOptions: AuthenticationOptionsKV,
   ): Promise<void> {
     await this.getKv().set(
       [KV_AUTHENTICATION_OPTIONS, requestId],
       authenticationOptions,
       {
-        expireIn: 60 * 1_000,
-      }
+        expireIn: KV_OPTIONS_EXPIRATION_TIME,
+      },
     );
   }
 
   public async deleteAuthenticationOptionsByTransactionId(
-    transactionId: string
+    transactionId: string,
   ): Promise<void> {
     await this.getKv().delete([KV_AUTHENTICATION_OPTIONS, transactionId]);
   }
 
   public async getConfiguration(): Promise<ConfigurationType | null> {
-    const entry: Deno.KvEntryMaybe<ConfigurationType> =
-      await this.getKv().get<ConfigurationType>([KV_CONFIGURATION]);
+    const entry: Deno.KvEntryMaybe<ConfigurationType> = await this.getKv().get<
+      ConfigurationType
+    >([KV_CONFIGURATION]);
 
     return entry.value;
   }
 
   public async setConfiguration(
-    configuration: ConfigurationType
+    configuration: ConfigurationType,
   ): Promise<void> {
     await this.getKv().set([KV_CONFIGURATION], configuration);
   }
@@ -131,7 +135,7 @@ export class KVService {
   }
 
   public async deleteUserTemporaryData(
-    userId: string
+    userId: string,
   ): Promise<Deno.KvCommitResult | Deno.KvCommitError> {
     return await this.getKv().atomic().delete([KV_USER_KEYS, userId]).commit();
   }


### PR DESCRIPTION
## Summary
- set KV registration/auth option TTL via shared KV_OPTIONS_EXPIRATION_TIME
- reduce KV_OPTIONS_EXPIRATION_TIME constant to one minute

## Testing
- `deno lint src/api/versions/v1/constants/kv-constants.ts src/api/versions/v1/services/kv-service.ts`
- `deno check --unsafely-ignore-certificate-errors src/main.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bd81fe59248327a679e10c5bad5a10