### PR TITLE
Align KV option TTL with validation window

### DIFF
--- a/src/api/versions/v1/constants/kv-constants.ts
+++ b/src/api/versions/v1/constants/kv-constants.ts
@@ -5,4 +5,4 @@ export const KV_AUTHENTICATION_OPTIONS = "authentication_options";
 export const KV_CONFIGURATION = "configuration";
 export const KV_USER_KEYS = "user_keys";
 
-export const KV_OPTIONS_EXPIRATION_TIME = 5 * 60 * 1000;
+export const KV_OPTIONS_EXPIRATION_TIME = 1 * 60 * 1000;

--- a/src/api/versions/v1/services/kv-service.ts
+++ b/src/api/versions/v1/services/kv-service.ts
@@ -7,6 +7,7 @@ import {
   KV_SIGNATURE_KEYS,
   KV_USER_KEYS,
   KV_VERSION,
+  KV_OPTIONS_EXPIRATION_TIME,
 } from "../constants/kv-constants.ts";
 import { AuthenticationOptionsKV } from "../interfaces/kv/authentication-options-kv.ts";
 import { RegistrationOptionsKV } from "../interfaces/kv/registration-options-kv.ts";
@@ -84,7 +85,7 @@ export class KVService {
       [KV_REGISTRATION_OPTIONS, transactionId],
       registrationOptions,
       {
-        expireIn: 60 * 1_000,
+        expireIn: KV_OPTIONS_EXPIRATION_TIME,
       },
     );
   }
@@ -136,7 +137,7 @@ export class KVService {
       [KV_AUTHENTICATION_OPTIONS, requestId],
       authenticationOptions,
       {
-        expireIn: 60 * 1_000,
+        expireIn: KV_OPTIONS_EXPIRATION_TIME,
       },
     );
   }


### PR DESCRIPTION
## Summary
- align registration/authentication option TTL with validation window
- shorten KV option expiration window to 1 minute

## Testing
- `deno task check` *(fails: invalid peer certificate for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68bd84e62e388327b4673be4452eae1c