### PR TITLE
feat: paginate server messages

### DIFF
--- a/src/api/versions/v1/routers/authenticated/authenticated-server-messages-router.ts
+++ b/src/api/versions/v1/routers/authenticated/authenticated-server-messages-router.ts
@@ -1,7 +1,10 @@
 import { inject, injectable } from "@needle-di/core";
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { ServerMessagesService } from "../../services/server-messages-service.ts";
-import { GetServerMessageResponseSchema } from "../../schemas/server-messages-schemas.ts";
+import {
+  GetServerMessagesQuerySchema,
+  GetServerMessagesResponseSchema,
+} from "../../schemas/server-messages-schemas.ts";
 import { ServerResponse } from "../../models/server-response.ts";
 
 @injectable()
@@ -30,12 +33,15 @@ export class AuthenticatedServerMessagesRouter {
         description:
           "Server messages shown to the player after connecting to server",
         tags: ["Server message"],
+        request: {
+          query: GetServerMessagesQuerySchema,
+        },
         responses: {
           200: {
             description: "Responds with data",
             content: {
               "application/json": {
-                schema: GetServerMessageResponseSchema,
+                schema: GetServerMessagesResponseSchema,
               },
             },
           },
@@ -43,10 +49,14 @@ export class AuthenticatedServerMessagesRouter {
         },
       }),
       async (c) => {
-        const response = await this.serverMessagesService.list();
+        const { cursor, limit } = c.req.valid("query");
+        const response = await this.serverMessagesService.list({
+          cursor,
+          limit,
+        });
 
         return c.json(response, 200);
-      }
+      },
     );
   }
 }

--- a/src/api/versions/v1/schemas/server-messages-schemas.ts
+++ b/src/api/versions/v1/schemas/server-messages-schemas.ts
@@ -1,4 +1,8 @@
 import { z } from "@hono/zod-openapi";
+import {
+  PaginatedResponseSchema,
+  PaginationSchema,
+} from "./pagination-schemas.ts";
 
 export const CreateServerMessageRequestSchema = z.object({
   title: z
@@ -29,30 +33,38 @@ export type DeleteServerMessageRequest = z.infer<
   typeof DeleteServerMessageRequestSchema
 >;
 
-export const GetServerMessageResponseSchema = z.array(
-  z.object({
-    id: z.number().describe("The message ID").openapi({ example: 1 }),
-    title: z
-      .string()
-      .describe("The message title")
-      .openapi({ example: "Hello world!" }),
-    content: z.string().describe("The message content").openapi({
-      example: "This is a really great message just for you.",
-    }),
-    createdAt: z
-      .number()
-      .describe("The message created timestamp")
-      .openapi({ example: 1740325296918 }),
-    updatedAt: z
-      .optional(z.number())
-      .describe("The message updated timestamp")
-      .openapi({ example: 1740325296918 }),
-  })
+export const ServerMessageResponseSchema = z.object({
+  id: z.number().describe("The message ID").openapi({ example: 1 }),
+  title: z
+    .string()
+    .describe("The message title")
+    .openapi({ example: "Hello world!" }),
+  content: z.string().describe("The message content").openapi({
+    example: "This is a really great message just for you.",
+  }),
+  createdAt: z
+    .number()
+    .describe("The message created timestamp")
+    .openapi({ example: 1740325296918 }),
+  updatedAt: z
+    .number()
+    .describe("The message updated timestamp")
+    .openapi({ example: 1740325296918 }),
+});
+
+export type ServerMessageResponse = z.infer<
+  typeof ServerMessageResponseSchema
+>;
+
+export const GetServerMessagesResponseSchema = PaginatedResponseSchema(
+  ServerMessageResponseSchema,
 );
 
-export type GetServerMessageResponse = z.infer<
-  typeof GetServerMessageResponseSchema
+export type GetServerMessagesResponse = z.infer<
+  typeof GetServerMessagesResponseSchema
 >;
+
+export const GetServerMessagesQuerySchema = PaginationSchema;
 
 export const UpdateServerMessageRequestSchema = z.object({
   id: z.coerce

--- a/src/api/versions/v1/services/server-messages-service.ts
+++ b/src/api/versions/v1/services/server-messages-service.ts
@@ -8,7 +8,7 @@ import {
 } from "../schemas/server-messages-schemas.ts";
 import { PaginationParams } from "../schemas/pagination-schemas.ts";
 import { serverMessagesTable } from "../../../../db/schema.ts";
-import { eq, gt } from "drizzle-orm";
+import { desc, eq, lt } from "drizzle-orm";
 import { ServerError } from "../models/server-error.ts";
 
 @injectable()
@@ -23,11 +23,11 @@ export class ServerMessagesService {
 
     let query = db.select().from(serverMessagesTable);
     if (cursor) {
-      query = query.where(gt(serverMessagesTable.id, cursor));
+      query = query.where(lt(serverMessagesTable.id, cursor));
     }
 
     const messages = await query
-      .orderBy(serverMessagesTable.id)
+      .orderBy(desc(serverMessagesTable.id))
       .limit(limit + 1);
 
     const hasNextPage = messages.length > limit;


### PR DESCRIPTION
## Summary
- add pagination schemas for server messages
- implement cursor-based pagination in server messages service
- expose cursor/limit query params on authenticated server messages endpoint

## Testing
- `deno fmt src/api/versions/v1/schemas/server-messages-schemas.ts src/api/versions/v1/services/server-messages-service.ts src/api/versions/v1/routers/authenticated/authenticated-server-messages-router.ts`
- `deno task check` *(fails: invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68bd87c504bc83278c1088180067bf0d