### PR TITLE
Persist banned users in KV to block websocket reconnects

### DIFF
--- a/src/api/versions/v1/constants/kv-constants.ts
+++ b/src/api/versions/v1/constants/kv-constants.ts
@@ -4,5 +4,6 @@ export const KV_REGISTRATION_OPTIONS = "registration_options";
 export const KV_AUTHENTICATION_OPTIONS = "authentication_options";
 export const KV_CONFIGURATION = "configuration";
 export const KV_USER_KEYS = "user_keys";
+export const KV_BANNED_USERS = "banned_users";
 
 export const KV_OPTIONS_EXPIRATION_TIME = 1 * 60 * 1000;


### PR DESCRIPTION
## Summary
- store banned users in Deno KV and expose helpers
- prevent banned users from reconnecting to websocket
- update user moderation to sync bans with KV

## Testing
- `deno fmt src/api/versions/v1/constants/kv-constants.ts src/api/versions/v1/services/kv-service.ts src/api/versions/v1/services/user-moderation-service.ts src/api/versions/v1/services/websocket-service.ts`
- `deno lint src/api/versions/v1/constants/kv-constants.ts src/api/versions/v1/services/kv-service.ts src/api/versions/v1/services/user-moderation-service.ts src/api/versions/v1/services/websocket-service.ts`
- `deno task check` *(fails: invalid peer certificate UnknownIssuer for esbuild package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd92f4d90c8327a73e7deb613fbc7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced user banning with optional durations (minutes to years) and support for permanent bans.
  - Immediate enforcement: banned users are blocked from real-time connections and sessions.
  - Unbanning instantly restores access across the app.
  - Improved reliability of ban application with transactional handling and duplicate protection.
  - Clearer logging around ban status and expiration to aid moderation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->