### PR TITLE
Guard Drizzle workflows for forks and limit runtime

### DIFF
--- a/.github/workflows/update-drizzle-preview.yml
+++ b/.github/workflows/update-drizzle-preview.yml
@@ -3,12 +3,18 @@ name: Update Drizzle schema (Preview)
 on:
   pull_request:
 
+concurrency:
+  group: update-drizzle-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   update-drizzle:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: Preview
     permissions:
       contents: write
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/update-drizzle-production.yml
+++ b/.github/workflows/update-drizzle-production.yml
@@ -5,12 +5,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: update-drizzle-production-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-drizzle:
     runs-on: ubuntu-latest
     environment: Production
     permissions:
       contents: write
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Skip Drizzle schema update workflow on forked PRs to avoid secret/push failures
- Add concurrency and 10m timeout to Drizzle schema update workflows to prevent overlapping runs and runaway jobs

## Testing
- `deno fmt .github/workflows/update-drizzle-preview.yml .github/workflows/update-drizzle-production.yml`
- `deno task check` *(fails: invalid peer certificate for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fc8d71ec8327968533fd4ddd3709