### PR TITLE
fix: enable attribute filtering for matches

### DIFF
--- a/src/api/versions/v1/services/matches-service.ts
+++ b/src/api/versions/v1/services/matches-service.ts
@@ -88,14 +88,11 @@ export class MatchesService {
     }
 
     // Add attribute conditions using jsonb operators
-    if (body.attributes) {
-      // FIX: not working correctly
-      /*       for (const [key, value] of Object.entries(body.attributes)) {
-        // Use ->> operator for exact value match (handles non-existent keys gracefully)
-        conditions.push(
-          sql`${matchesTable.attributes}->>${key} = ${JSON.stringify(value)}`
-        );
-      } */
+    if (body.attributes && Object.keys(body.attributes).length > 0) {
+      // Ensure all provided attributes are matched in the stored attributes
+      conditions.push(
+        sql`${matchesTable.attributes} @> ${body.attributes}::jsonb`,
+      );
     }
 
     // Get one extra item to determine if there are more results


### PR DESCRIPTION
## Summary
- enable match attribute filtering using jsonb containment

## Testing
- `deno check src/main.ts` *(fails: JSR package manifest for '@needle-di/core' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68c80ca48f68832780a2d3fe715b3cc7