### PR TITLE
'Fix: Remove invalid --unstable-* args from deploy config'

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "@types/pg": "npm:@types/pg@^8.20.0",
     "drizzle-kit": "npm:drizzle-kit@^0.31.10",
     "drizzle-orm": "npm:drizzle-orm@^0.45.2",
-    "pg": "npm:pg@^8.22.0",
+    "pg": "npm:pg@^8.21.0",
     "hono": "npm:hono@^4.12.26",
     "zod": "npm:zod@^4.4.3"
   },

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "@types/pg": "npm:@types/pg@^8.20.0",
     "drizzle-kit": "npm:drizzle-kit@^0.31.10",
     "drizzle-orm": "npm:drizzle-orm@^0.45.2",
-    "pg": "npm:pg@^8.21.0",
+    "pg": "npm:pg@^8.22.0",
     "hono": "npm:hono@^4.12.26",
     "zod": "npm:zod@^4.4.3"
   },
@@ -43,7 +43,7 @@
     "predeploy": "deno task migrate",
     "runtime": {
       "entrypoint": "src/main.ts",
-      "args": ["--unstable-kv", "--unstable-broadcast-channel"]
+      "args": []
     }
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -18,7 +18,6 @@
     "npm:drizzle-kit@~0.31.10": "0.31.10",
     "npm:drizzle-orm@~0.45.2": "0.45.2_@types+pg@8.20.0_pg@8.22.0",
     "npm:hono@^4.12.26": "4.12.26",
-    "npm:pg@^8.22.0": "8.22.0",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
@@ -937,7 +936,7 @@
       "npm:drizzle-kit@~0.31.10",
       "npm:drizzle-orm@~0.45.2",
       "npm:hono@^4.12.26",
-      "npm:pg@^8.22.0",
+      "npm:pg@^8.21.0",
       "npm:zod@^4.4.3"
     ]
   }


### PR DESCRIPTION
'Deno Deploy runtime does not accept these custom flags. This likely corrupts runtime config initialization, causing database env vars to not get injected.'