### PR TITLE
fix: prevent double-wrapping Cloudflare ICE servers array

### DIFF
--- a/src/api/versions/v1/services/ice-service.ts
+++ b/src/api/versions/v1/services/ice-service.ts
@@ -47,6 +47,7 @@ export class ICEService {
 
     const data = await response.json();
 
-    return [data.iceServers];
+    // data.iceServers is already an array of RTCIceServer objects from Cloudflare Calls API
+    return data.iceServers;
   }
 }


### PR DESCRIPTION
## Problem

The game client fails to join matches with:
\\\
TypeError: Failed to construct 'RTCPeerConnection': Malformed RTCIceServer
\\\

## Root Cause

\ICEService.getCloudflareServers()\ at \src/api/versions/v1/services/ice-service.ts:50\ was wrapping \data.iceServers\ in an extra array (\[data.iceServers]\).

The Cloudflare Calls API already returns \data.iceServers\ as an \RTCIceServer[]\ array. The extra wrapping produced a nested array (\[[{...}, {...}]]\), causing the first ICE server to be an array instead of an object.

## Fix

Changed \eturn [data.iceServers]\ to \eturn data.iceServers\ and added a comment to prevent regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cloudflare server results so they are returned in the expected format, preventing unintended nested arrays.
  * Added a clarifying note to make the behavior easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->