### PR TITLE
fix: detect stale credential counter with returning() guard

### DIFF
--- a/src/api/versions/v1/services/credentials-service.ts
+++ b/src/api/versions/v1/services/credentials-service.ts
@@ -46,7 +46,7 @@ export class CredentialsService {
     newCounter: number,
   ): Promise<void> {
     try {
-      await this.databaseService.executeWithCredentialAndUserContext(
+      const result = await this.databaseService.executeWithCredentialAndUserContext(
         id,
         userId,
         (tx) => {
@@ -58,9 +58,16 @@ export class CredentialsService {
                 eq(userCredentialsTable.id, id),
                 lt(userCredentialsTable.counter, newCounter),
               ),
-            );
+            )
+            .returning({ id: userCredentialsTable.id });
         },
       );
+
+      if (result.length === 0 && newCounter > 0) {
+        console.warn(
+          `Credential counter not advanced for ${id}: stored >= ${newCounter}. Possible race condition or credential cloning.`,
+        );
+      }
     } catch (error) {
       console.error("Failed to update credential counter:", error);
       throw new ServerError(


### PR DESCRIPTION
## Summary

Fixes a silent no-op in the credential counter update. When lt() prevents the update (stored counter >= new counter), the flow now detects this via .returning() and logs a warning for counter-capable authenticators.

## Change

**credentials-service.ts** -- updateCounter() method:
- Added .returning({ id }) to capture whether rows were affected
- When result.length === 0 and newCounter > 0: logs a warning (potential cloning, race condition, or authenticator malfunction)
- When result.length === 0 and newCounter === 0: silent (non-counter authenticator, per spec)
- When rows were updated: behavior unchanged

## Spec Compliance

Follows the WebAuthn Level 3 spec (Section 6.1.1 Signature Counter Considerations):
- "If either is non-zero, and the new signCount value is less than or equal to the stored value, a cloned authenticator may exist"
- "Relying Parties should address this situation appropriately relative to their individual situations"

Current approach: detect + log (low-risk). Easy to escalate to rejection later if needed.

## Verification
- [x] Type check passes (deno task check)
- [x] No behavioral change for non-counter authenticators
- [x] No behavioral change for successful counter advances


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved counter update handling so the app can detect when a stored value does not advance as expected.
  * Added a warning when an update is skipped because an existing counter is already at or above the new value, helping surface potential data conflicts or race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->