### PR TITLE
feat: add hourly cron cleanup for expired auth data

### DIFF
--- a/crons/cleanup-authentication-challenges-cron.ts
+++ b/crons/cleanup-authentication-challenges-cron.ts
@@ -1,0 +1,25 @@
+import { lt } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { DatabaseService } from "../src/core/services/database-service.ts";
+import { authenticationChallengesTable } from "../src/db/schema.ts";
+
+export function registerCleanupAuthenticationChallengesCron(
+  databaseService: DatabaseService,
+): void {
+  Deno.cron("cleanup-authentication-challenges", "0 * * * *", async () => {
+    const db = databaseService.get();
+
+    const result = await db
+      .delete(authenticationChallengesTable)
+      .where(
+        lt(
+          authenticationChallengesTable.createdAt,
+          sql`now() - interval '1 hour'`,
+        ),
+      );
+
+    console.log(
+      `[cron] Cleaned up ${result.rowCount} expired authentication challenges`,
+    );
+  });
+}

--- a/crons/cleanup-refresh-tokens-cron.ts
+++ b/crons/cleanup-refresh-tokens-cron.ts
@@ -1,0 +1,22 @@
+import { lt } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { DatabaseService } from "../src/core/services/database-service.ts";
+import { refreshTokensTable } from "../src/db/schema.ts";
+
+export function registerCleanupRefreshTokensCron(
+  databaseService: DatabaseService,
+): void {
+  Deno.cron("cleanup-refresh-tokens", "0 * * * *", async () => {
+    const db = databaseService.get();
+
+    const result = await db
+      .delete(refreshTokensTable)
+      .where(
+        lt(refreshTokensTable.expiresAt, sql`now()`),
+      );
+
+    console.log(
+      `[cron] Cleaned up ${result.rowCount} expired refresh tokens`,
+    );
+  });
+}

--- a/crons/cleanup-user-sessions-cron.ts
+++ b/crons/cleanup-user-sessions-cron.ts
@@ -1,0 +1,25 @@
+import { lt } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { DatabaseService } from "../src/core/services/database-service.ts";
+import { userSessionsTable } from "../src/db/schema.ts";
+
+export function registerCleanupUserSessionsCron(
+  databaseService: DatabaseService,
+): void {
+  Deno.cron("cleanup-user-sessions", "0 * * * *", async () => {
+    const db = databaseService.get();
+
+    const result = await db
+      .delete(userSessionsTable)
+      .where(
+        lt(
+          userSessionsTable.updatedAt,
+          sql`now() - interval '30 days'`,
+        ),
+      );
+
+    console.log(
+      `[cron] Cleaned up ${result.rowCount} stale user sessions`,
+    );
+  });
+}

--- a/deno.lock
+++ b/deno.lock
@@ -17,6 +17,7 @@
     "npm:@types/pg@^8.20.0": "8.20.0",
     "npm:drizzle-kit@*": "0.31.10",
     "npm:drizzle-kit@beta": "1.0.0-beta.22",
+    "npm:drizzle-orm@*": "0.45.2_@types+pg@8.20.0_pg@8.22.0",
     "npm:drizzle-orm@beta": "1.0.0-beta.22_@types+pg@8.20.0_pg@8.22.0_zod@4.4.3",
     "npm:hono@^4.12.27": "4.12.27",
     "npm:pg@^8.22.0": "8.22.0",
@@ -680,6 +681,17 @@
         "jiti"
       ],
       "bin": true
+    },
+    "drizzle-orm@0.45.2_@types+pg@8.20.0_pg@8.22.0": {
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "dependencies": [
+        "@types/pg",
+        "pg"
+      ],
+      "optionalPeers": [
+        "@types/pg",
+        "pg"
+      ]
     },
     "drizzle-orm@1.0.0-beta.22_@types+pg@8.20.0_pg@8.22.0_zod@4.4.3": {
       "integrity": "sha512-F+DZyVIvH0oVKa/w08Cle1xfoH+pc+htIXHG/frnMLG72aby9NYYr9oc+9XvghnoO4umxFItduz0OMmQJMnenw==",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,18 @@
 import { Container } from "@needle-di/core";
 import { HTTPService } from "./core/services/http-service.ts";
 import { DatabaseService } from "./core/services/database-service.ts";
+import { registerCleanupAuthenticationChallengesCron } from "../crons/cleanup-authentication-challenges-cron.ts";
+import { registerCleanupRefreshTokensCron } from "../crons/cleanup-refresh-tokens-cron.ts";
+import { registerCleanupUserSessionsCron } from "../crons/cleanup-user-sessions-cron.ts";
 
 const container = new Container();
 
 const databaseService = container.get(DatabaseService);
 databaseService.init();
+
+registerCleanupAuthenticationChallengesCron(databaseService);
+registerCleanupRefreshTokensCron(databaseService);
+registerCleanupUserSessionsCron(databaseService);
 
 const httpService = container.get(HTTPService);
 await httpService.listen();


### PR DESCRIPTION
Adds three Deno cron jobs running every hour to clean up expired/stale data:

- **Authentication challenges** — deletes challenges older than 1 hour
- **Refresh tokens** — deletes tokens past their \xpires_at\
- **User sessions** — deletes sessions not updated in 30+ days

Each cron is in its own file under \crons/\ and registered in \src/main.ts\.

No RLS policy changes needed — the cron runs as the database owner via \DATABASE_URL\.