### PR TITLE
refactor: store auth challenge data directly, use DB createdAt for expiration

### DIFF
--- a/src/api/versions/v1/services/authentication-challenges-service.ts
+++ b/src/api/versions/v1/services/authentication-challenges-service.ts
@@ -25,7 +25,7 @@ export class AuthenticationChallengesService {
   public async consume<T>(
     transactionId: string,
     type: string,
-  ): Promise<T | null> {
+  ): Promise<{ data: T; createdAt: Date } | null> {
     const rows = await this.databaseService
       .get()
       .delete(authenticationChallengesTable)
@@ -37,10 +37,11 @@ export class AuthenticationChallengesService {
       )
       .returning({
         data: authenticationChallengesTable.data,
+        createdAt: authenticationChallengesTable.createdAt,
       });
 
     if (rows.length === 0) return null;
 
-    return rows[0].data as T;
+    return { data: rows[0].data as T, createdAt: rows[0].createdAt };
   }
 }

--- a/src/api/versions/v1/services/authentication-service.ts
+++ b/src/api/versions/v1/services/authentication-service.ts
@@ -76,7 +76,7 @@ export class AuthenticationService {
     await this.authenticationChallengesService.save(
       transactionId,
       "authentication",
-      { data: options, createdAt: Date.now() },
+      options as unknown as Record<string, unknown>,
     );
 
     return options;
@@ -299,10 +299,7 @@ export class AuthenticationService {
   private async getAuthenticationOptionsOrThrow(
     transactionId: string,
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
-    const challenge = await this.authenticationChallengesService.consume<{
-      data: PublicKeyCredentialRequestOptionsJSON;
-      createdAt: number;
-    }>(
+    const challenge = await this.authenticationChallengesService.consume<PublicKeyCredentialRequestOptionsJSON>(
       transactionId,
       "authentication",
     );
@@ -315,7 +312,7 @@ export class AuthenticationService {
       );
     }
 
-    if (challenge.createdAt + OPTIONS_EXPIRATION_TIME < Date.now()) {
+    if (challenge.createdAt.getTime() + OPTIONS_EXPIRATION_TIME < Date.now()) {
       throw new ServerError(
         "AUTHENTICATION_OPTIONS_EXPIRED",
         "Authentication options expired",

--- a/src/api/versions/v1/services/registration-service.ts
+++ b/src/api/versions/v1/services/registration-service.ts
@@ -71,7 +71,7 @@ export class RegistrationService {
     await this.authenticationChallengesService.save(
       transactionId,
       "registration",
-      { data: options, createdAt: Date.now() },
+      options as unknown as Record<string, unknown>,
     );
 
     return options;
@@ -142,10 +142,7 @@ export class RegistrationService {
   private async consumeRegistrationOptionsOrThrow(
     transactionId: string
   ): Promise<PublicKeyCredentialCreationOptionsJSON> {
-    const challenge = await this.authenticationChallengesService.consume<{
-      data: PublicKeyCredentialCreationOptionsJSON;
-      createdAt: number;
-    }>(
+    const challenge = await this.authenticationChallengesService.consume<PublicKeyCredentialCreationOptionsJSON>(
       transactionId,
       "registration",
     );
@@ -158,7 +155,7 @@ export class RegistrationService {
       );
     }
 
-    if (challenge.createdAt + OPTIONS_EXPIRATION_TIME < Date.now()) {
+    if (challenge.createdAt.getTime() + OPTIONS_EXPIRATION_TIME < Date.now()) {
       throw new ServerError(
         "REGISTRATION_OPTIONS_EXPIRED",
         "Registration options expired",


### PR DESCRIPTION
Changes the authentication challenges data column to store WebAuthn options directly instead of wrapping them in \{ data, createdAt }\ objects. The \created_at\ database column is now used for expiration control instead of an embedded timestamp in the JSON data.

### Changes
- **authentication-challenges-service.ts** — \consume()\ now returns both \data\ and \createdAt\ from the DB column  
- **registration-service.ts** — saves \options\ directly, uses \createdAt.getTime()\ for expiration  
- **authentication-service.ts** — same pattern as registration