### PR TITLE
feat: enable unstable-cron flag for Deno.cron() usage

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,7 @@
       "sys": true
     }
   },
-  "unstable": ["kv", "broadcast-channel"],
+  "unstable": ["kv", "broadcast-channel", "cron"],
   "compilerOptions": {
     "experimentalDecorators": true
   },
@@ -43,7 +43,7 @@
     "predeploy": "deno task migrate",
     "runtime": {
       "entrypoint": "src/main.ts",
-      "args": ["--unstable-kv", "--unstable-broadcast-channel"]
+      "args": ["--unstable-kv", "--unstable-broadcast-channel", "--unstable-cron"]
     }
   }
 }


### PR DESCRIPTION
Adds cron to the unstable array in deno.json and --unstable-cron to deploy args to resolve the Deno warning about Deno.cron() being an unstable API.