### PR TITLE
feat: add device authorization flow for bot sign-in

### DIFF
--- a/crons/cleanup-device-authorization-codes-cron.ts
+++ b/crons/cleanup-device-authorization-codes-cron.ts
@@ -1,0 +1,22 @@
+import { lt } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { DatabaseService } from "../src/core/services/database-service.ts";
+import { deviceAuthorizationCodesTable } from "../src/db/schema.ts";
+
+export function registerCleanupDeviceAuthorizationCodesCron(
+  databaseService: DatabaseService,
+): void {
+  Deno.cron("cleanup-device-authorization-codes", "0 * * * *", async () => {
+    const db = databaseService.get();
+
+    const result = await db
+      .delete(deviceAuthorizationCodesTable)
+      .where(
+        lt(deviceAuthorizationCodesTable.expiresAt, sql`now()`),
+      );
+
+    console.log(
+      `[cron] Cleaned up ${result.rowCount} expired device authorization codes`,
+    );
+  });
+}

--- a/drizzle/20260731123905_polite_professor_monster/migration.sql
+++ b/drizzle/20260731123905_polite_professor_monster/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "device_authorization_codes" (
+	"code" varchar(16) PRIMARY KEY,
+	"encrypted_tokens" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "device_authorization_codes" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY "device_authorization_codes_all_insert" ON "device_authorization_codes" AS PERMISSIVE FOR INSERT TO "authenticated_user" WITH CHECK (true);--> statement-breakpoint
+CREATE POLICY "device_authorization_codes_all_delete" ON "device_authorization_codes" AS PERMISSIVE FOR DELETE TO "authenticated_user" USING (true);

--- a/drizzle/20260731123905_polite_professor_monster/snapshot.json
+++ b/drizzle/20260731123905_polite_professor_monster/snapshot.json
@@ -1,0 +1,2226 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "274b87f5-503d-4641-8779-8ab5c8189bbf",
+  "prevIds": [
+    "73bf5f48-d50e-4860-a881-fc589cbd19c5"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "authentication_challenges",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "blocked_words",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "device_authorization_codes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "game_configuration",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "match_users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "matches",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "refresh_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_signature_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_bans",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_credentials",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_encryption_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_reports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_scores",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "blocked_words_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "word",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "encrypted_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "match_users_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "match_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "matches_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "host_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "total_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "available_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "ping_median_milliseconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attributes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "server_messages_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "private_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_bans_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backup_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transports",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_reports_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reporter_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reported_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "automatic",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_scores_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_score",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar(44)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_ip",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "country",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lower(\"word\")",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "unique_lower_word",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "match_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_match_id_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "match_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "matches",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_match_id_matches_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "matches_host_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "refresh_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_bans_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_credentials_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_encryption_keys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reporter_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reporter_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reported_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reported_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "role_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "roles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_role_id_roles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_scores_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "authentication_challenges_pkey",
+      "schema": "public",
+      "table": "authentication_challenges",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "blocked_words_pkey",
+      "schema": "public",
+      "table": "blocked_words",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "code"
+      ],
+      "nameExplicit": false,
+      "name": "device_authorization_codes_pkey",
+      "schema": "public",
+      "table": "device_authorization_codes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "game_configuration_pkey",
+      "schema": "public",
+      "table": "game_configuration",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "match_users_pkey",
+      "schema": "public",
+      "table": "match_users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "matches_pkey",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "token_hash"
+      ],
+      "nameExplicit": false,
+      "name": "refresh_tokens_pkey",
+      "schema": "public",
+      "table": "refresh_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "roles_pkey",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_messages_pkey",
+      "schema": "public",
+      "table": "server_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_signature_keys_pkey",
+      "schema": "public",
+      "table": "server_signature_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_bans_pkey",
+      "schema": "public",
+      "table": "user_bans",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_credentials_pkey",
+      "schema": "public",
+      "table": "user_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_encryption_keys_pkey",
+      "schema": "public",
+      "table": "user_encryption_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_reports_pkey",
+      "schema": "public",
+      "table": "user_reports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_roles_pkey",
+      "schema": "public",
+      "table": "user_roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_scores_pkey",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_sessions_pkey",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "transaction_id",
+        "type"
+      ],
+      "nullsNotDistinct": false,
+      "name": "authentication_challenges_transaction_id_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "user_id",
+        "role_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_roles_user_id_role_id_idx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "matches_host_user_id_key",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "roles_name_key",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_scores_user_id_key",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_sessions_token_key",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "display_name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_display_name_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"id\" = 1",
+      "name": "server_signature_keys_singleton",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "authentication_challenges_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_select",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "device_authorization_codes_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "device_authorization_codes_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "name": "refresh_tokens_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_bans\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_bans_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\") AND (current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_roles\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_roles_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": null,
+      "name": "users_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "name": "users_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/20260731130425_greedy_piledriver/migration.sql
+++ b/drizzle/20260731130425_greedy_piledriver/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "device_authorization_codes" ALTER COLUMN "encrypted_tokens" DROP NOT NULL;--> statement-breakpoint
+CREATE POLICY "device_authorization_codes_all_update" ON "device_authorization_codes" AS PERMISSIVE FOR UPDATE TO "authenticated_user" USING (true) WITH CHECK (true);

--- a/drizzle/20260731130425_greedy_piledriver/snapshot.json
+++ b/drizzle/20260731130425_greedy_piledriver/snapshot.json
@@ -1,0 +1,2239 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "612e66c0-60c4-4a18-8784-a384e66a22b3",
+  "prevIds": [
+    "274b87f5-503d-4641-8779-8ab5c8189bbf"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "authentication_challenges",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "blocked_words",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "device_authorization_codes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "game_configuration",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "match_users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "matches",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "refresh_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_signature_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_bans",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_credentials",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_encryption_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_reports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_scores",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "blocked_words_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "word",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "encrypted_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "match_users_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "match_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "matches_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "host_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "total_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "available_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "ping_median_milliseconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attributes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "server_messages_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "private_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_bans_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backup_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transports",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_reports_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reporter_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reported_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "automatic",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_scores_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_score",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar(44)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_ip",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "country",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lower(\"word\")",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "unique_lower_word",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "match_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_match_id_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "match_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "matches",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_match_id_matches_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "matches_host_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "refresh_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_bans_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_credentials_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_encryption_keys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reporter_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reporter_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reported_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reported_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "role_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "roles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_role_id_roles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_scores_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "authentication_challenges_pkey",
+      "schema": "public",
+      "table": "authentication_challenges",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "blocked_words_pkey",
+      "schema": "public",
+      "table": "blocked_words",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "code"
+      ],
+      "nameExplicit": false,
+      "name": "device_authorization_codes_pkey",
+      "schema": "public",
+      "table": "device_authorization_codes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "game_configuration_pkey",
+      "schema": "public",
+      "table": "game_configuration",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "match_users_pkey",
+      "schema": "public",
+      "table": "match_users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "matches_pkey",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "token_hash"
+      ],
+      "nameExplicit": false,
+      "name": "refresh_tokens_pkey",
+      "schema": "public",
+      "table": "refresh_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "roles_pkey",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_messages_pkey",
+      "schema": "public",
+      "table": "server_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_signature_keys_pkey",
+      "schema": "public",
+      "table": "server_signature_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_bans_pkey",
+      "schema": "public",
+      "table": "user_bans",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_credentials_pkey",
+      "schema": "public",
+      "table": "user_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_encryption_keys_pkey",
+      "schema": "public",
+      "table": "user_encryption_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_reports_pkey",
+      "schema": "public",
+      "table": "user_reports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_roles_pkey",
+      "schema": "public",
+      "table": "user_roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_scores_pkey",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_sessions_pkey",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "transaction_id",
+        "type"
+      ],
+      "nullsNotDistinct": false,
+      "name": "authentication_challenges_transaction_id_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "user_id",
+        "role_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_roles_user_id_role_id_idx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "matches_host_user_id_key",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "roles_name_key",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_scores_user_id_key",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_sessions_token_key",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "display_name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_display_name_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"id\" = 1",
+      "name": "server_signature_keys_singleton",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "authentication_challenges_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_select",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "device_authorization_codes_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": "true",
+      "name": "device_authorization_codes_all_update",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "device_authorization_codes_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "name": "refresh_tokens_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_bans\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_bans_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\") AND (current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_roles\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_roles_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": null,
+      "name": "users_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "name": "users_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/20260731132811_stiff_golden_guardian/migration.sql
+++ b/drizzle/20260731132811_stiff_golden_guardian/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "device_authorization_codes" ADD CONSTRAINT "device_authorization_codes_code_format" CHECK (code ~ '^[A-Z0-9]{16}$');--> statement-breakpoint
+CREATE POLICY "device_authorization_codes_all_select" ON "device_authorization_codes" AS PERMISSIVE FOR SELECT TO "authenticated_user" USING (true);

--- a/drizzle/20260731132811_stiff_golden_guardian/snapshot.json
+++ b/drizzle/20260731132811_stiff_golden_guardian/snapshot.json
@@ -1,0 +1,2259 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "ab2bef20-1919-448b-8b4d-55127e341b4a",
+  "prevIds": [
+    "612e66c0-60c4-4a18-8784-a384e66a22b3"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "authentication_challenges",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "blocked_words",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "device_authorization_codes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "game_configuration",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "match_users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "matches",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "refresh_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_signature_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_bans",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_credentials",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_encryption_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_reports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_scores",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "blocked_words_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "word",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "encrypted_tokens",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "match_users_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "match_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "matches_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "host_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "total_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "available_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "ping_median_milliseconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attributes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "server_messages_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "private_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_bans_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backup_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transports",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_reports_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reporter_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reported_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "automatic",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_scores_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_score",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar(44)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_ip",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "country",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lower(\"word\")",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "unique_lower_word",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "match_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_match_id_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "match_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "matches",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_match_id_matches_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "matches_host_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "refresh_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_bans_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_credentials_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_encryption_keys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reporter_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reporter_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reported_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reported_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "role_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "roles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_role_id_roles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_scores_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "authentication_challenges_pkey",
+      "schema": "public",
+      "table": "authentication_challenges",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "blocked_words_pkey",
+      "schema": "public",
+      "table": "blocked_words",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "code"
+      ],
+      "nameExplicit": false,
+      "name": "device_authorization_codes_pkey",
+      "schema": "public",
+      "table": "device_authorization_codes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "game_configuration_pkey",
+      "schema": "public",
+      "table": "game_configuration",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "match_users_pkey",
+      "schema": "public",
+      "table": "match_users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "matches_pkey",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "token_hash"
+      ],
+      "nameExplicit": false,
+      "name": "refresh_tokens_pkey",
+      "schema": "public",
+      "table": "refresh_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "roles_pkey",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_messages_pkey",
+      "schema": "public",
+      "table": "server_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_signature_keys_pkey",
+      "schema": "public",
+      "table": "server_signature_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_bans_pkey",
+      "schema": "public",
+      "table": "user_bans",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_credentials_pkey",
+      "schema": "public",
+      "table": "user_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_encryption_keys_pkey",
+      "schema": "public",
+      "table": "user_encryption_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_reports_pkey",
+      "schema": "public",
+      "table": "user_reports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_roles_pkey",
+      "schema": "public",
+      "table": "user_roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_scores_pkey",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_sessions_pkey",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "transaction_id",
+        "type"
+      ],
+      "nullsNotDistinct": false,
+      "name": "authentication_challenges_transaction_id_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "user_id",
+        "role_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_roles_user_id_role_id_idx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "matches_host_user_id_key",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "roles_name_key",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_scores_user_id_key",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_sessions_token_key",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "display_name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_display_name_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "value": "code ~ '^[A-Z0-9]{16}$'",
+      "name": "device_authorization_codes_code_format",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "value": "\"id\" = 1",
+      "name": "server_signature_keys_singleton",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "authentication_challenges_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_select",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "device_authorization_codes_all_select",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "device_authorization_codes_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": "true",
+      "name": "device_authorization_codes_all_update",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "device_authorization_codes_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "device_authorization_codes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "name": "refresh_tokens_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_bans\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_bans_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\") AND (current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_roles\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_roles_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": null,
+      "name": "users_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "name": "users_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/src/api/versions/v1/constants/authentication-constants.ts
+++ b/src/api/versions/v1/constants/authentication-constants.ts
@@ -9,3 +9,6 @@ export const SESSION_LIFETIME_SECONDS = REFRESH_TOKEN_EXPIRATION_SECONDS;
 
 // Authentication/registration WebAuthn options TTL (ms)
 export const OPTIONS_EXPIRATION_TIME = 1 * 60 * 1000;
+
+// Device authorization code lifetime (ms)
+export const DEVICE_AUTHORIZATION_CODE_EXPIRATION_MS = 10 * 60 * 1000; // 10 minutes

--- a/src/api/versions/v1/routers/public/public-authentication-router.ts
+++ b/src/api/versions/v1/routers/public/public-authentication-router.ts
@@ -225,6 +225,7 @@ export class PublicAuthenticationRouter {
         responses: {
           ...ServerResponse.NoContent,
           ...ServerResponse.BadRequest,
+          ...ServerResponse.Unauthorized,
           ...ServerResponse.NotFound,
           ...ServerResponse.Forbidden,
         },

--- a/src/api/versions/v1/routers/public/public-authentication-router.ts
+++ b/src/api/versions/v1/routers/public/public-authentication-router.ts
@@ -3,6 +3,10 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { AuthenticationService } from "../../services/authentication-service.ts";
 import { getConnInfo } from "hono/deno";
 import {
+  DeviceAuthorizationCompleteRequestSchema,
+  DeviceAuthorizationMintResponseSchema,
+  DeviceAuthorizationPollRequestSchema,
+  DeviceAuthorizationPollResponseSchema,
   GetAuthenticationOptionsRequestSchema,
   GetAuthenticationOptionsResponseSchema,
   RefreshTokenRequestSchema,
@@ -11,13 +15,19 @@ import {
   VerifyAuthenticationResponseSchema,
 } from "../../schemas/authentication-schemas.ts";
 import { ServerResponse } from "../../models/server-response.ts";
+import { ServerError } from "../../models/server-error.ts";
 import { extractAndValidateOrigin } from "../../utils/origin-utils.ts";
+import { DeviceAuthorizationCodesService } from "../../services/device-authorization-codes-service.ts";
+import { WebAuthnUtils } from "../../../../../core/utils/webauthn-utils.ts";
 
 @injectable()
 export class PublicAuthenticationRouter {
   private app: OpenAPIHono;
 
-  constructor(private authenticationService = inject(AuthenticationService)) {
+  constructor(
+    private authenticationService = inject(AuthenticationService),
+    private deviceAuthorizationCodesService = inject(DeviceAuthorizationCodesService),
+  ) {
     this.app = new OpenAPIHono();
     this.setRoutes();
   }
@@ -30,6 +40,9 @@ export class PublicAuthenticationRouter {
     this.registerGetAuthenticationOptionsRoute();
     this.registerVerifyAuthenticationResponseRoute();
     this.registerRefreshTokenRoute();
+    this.registerDeviceAuthorizationMintRoute();
+    this.registerDeviceAuthorizationCompleteRoute();
+    this.registerDeviceAuthorizationPollRoute();
   }
 
   private registerGetAuthenticationOptionsRoute(): void {
@@ -157,6 +170,132 @@ export class PublicAuthenticationRouter {
         const response = await this.authenticationService.refreshTokens(validated);
 
         return c.json(response, 200);
+      },
+    );
+  }
+
+  private registerDeviceAuthorizationMintRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "post",
+        path: "/device-authorization",
+        summary: "Create a device authorization code",
+        description:
+          "Issues a new short-lived code the bot shows to the user to authorize a device",
+        tags: ["User authentication"],
+        responses: {
+          200: {
+            description: "Responds with the issued code and its expiry",
+            content: {
+              "application/json": {
+                schema: DeviceAuthorizationMintResponseSchema,
+              },
+            },
+          },
+          ...ServerResponse.BadRequest,
+        },
+      }),
+      async (c) => {
+        const { code, expiresAt } =
+          await this.deviceAuthorizationCodesService.create();
+
+        return c.json({ code, expiresAt: expiresAt.toISOString() }, 200);
+      },
+    );
+  }
+
+  private registerDeviceAuthorizationCompleteRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "post",
+        path: "/device-authorization/complete",
+        summary: "Store device authorization tokens",
+        description:
+          "Stores the token pair issued to a browser against a device authorization code",
+        tags: ["User authentication"],
+        request: {
+          body: {
+            content: {
+              "application/json": {
+                schema: DeviceAuthorizationCompleteRequestSchema,
+              },
+            },
+          },
+        },
+        responses: {
+          ...ServerResponse.NoContent,
+          ...ServerResponse.BadRequest,
+          ...ServerResponse.NotFound,
+          ...ServerResponse.Forbidden,
+        },
+      }),
+      async (c) => {
+        const validated = c.req.valid("json");
+        const origin = extractAndValidateOrigin(c);
+
+        if (!WebAuthnUtils.isOriginAllowed(origin)) {
+          throw new ServerError(
+            "ORIGIN_NOT_ALLOWED",
+            "Origin is not in the allowed list",
+            403,
+          );
+        }
+
+        await this.deviceAuthorizationCodesService.save(
+          validated.code,
+          validated.accessToken,
+          validated.refreshToken,
+        );
+
+        return c.body(null, 204);
+      },
+    );
+  }
+
+  private registerDeviceAuthorizationPollRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "post",
+        path: "/device-authorization/poll",
+        summary: "Retrieve device authorization tokens",
+        description:
+          "Returns and consumes the token pair stored for a device authorization code",
+        tags: ["User authentication"],
+        request: {
+          body: {
+            content: {
+              "application/json": {
+                schema: DeviceAuthorizationPollRequestSchema,
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Responds with the token pair",
+            content: {
+              "application/json": {
+                schema: DeviceAuthorizationPollResponseSchema,
+              },
+            },
+          },
+          ...ServerResponse.NotFound,
+        },
+      }),
+      async (c) => {
+        const { code } = c.req.valid("json");
+
+        const tokenPair = await this.deviceAuthorizationCodesService.consume(code);
+
+        if (tokenPair === null) {
+          throw new ServerError(
+            "DEVICE_AUTHORIZATION_CODE_NOT_FOUND",
+            "Device authorization code not found or expired",
+            404,
+          );
+        }
+
+        return c.json(tokenPair, 200);
       },
     );
   }

--- a/src/api/versions/v1/routers/public/public-authentication-router.ts
+++ b/src/api/versions/v1/routers/public/public-authentication-router.ts
@@ -182,7 +182,7 @@ export class PublicAuthenticationRouter {
         summary: "Create a device authorization code",
         description:
           "Issues a new short-lived code the bot shows to the user to authorize a device",
-        tags: ["User authentication"],
+        tags: ["Device authentication"],
         responses: {
           200: {
             description: "Responds with the issued code and its expiry",
@@ -212,7 +212,7 @@ export class PublicAuthenticationRouter {
         summary: "Store device authorization tokens",
         description:
           "Stores the token pair issued to a browser against a device authorization code",
-        tags: ["User authentication"],
+        tags: ["Device authentication"],
         request: {
           body: {
             content: {
@@ -261,7 +261,7 @@ export class PublicAuthenticationRouter {
         summary: "Retrieve device authorization tokens",
         description:
           "Returns and consumes the token pair stored for a device authorization code",
-        tags: ["User authentication"],
+        tags: ["Device authentication"],
         request: {
           body: {
             content: {

--- a/src/api/versions/v1/schemas/authentication-schemas.ts
+++ b/src/api/versions/v1/schemas/authentication-schemas.ts
@@ -121,3 +121,64 @@ export const RefreshTokenResponseSchema = z.object({
 });
 
 export type RefreshTokenResponse = z.infer<typeof RefreshTokenResponseSchema>;
+
+export const DeviceAuthorizationCodeSchema = z
+  .string()
+  .regex(
+    /^[A-Z0-9]{16}$/,
+    "Code must be exactly 16 uppercase alphanumeric characters",
+  )
+  .describe(
+    "Short-lived 16-character code printed by the bot for the pending authorization",
+  );
+
+export const DeviceAuthorizationMintResponseSchema = z.object({
+  code: DeviceAuthorizationCodeSchema,
+  expiresAt: z
+    .string()
+    .datetime()
+    .describe("Expiry timestamp (ISO 8601) of the issued code"),
+});
+
+export type DeviceAuthorizationMintResponse = z.infer<
+  typeof DeviceAuthorizationMintResponseSchema
+>;
+
+export const DeviceAuthorizationCompleteRequestSchema = z.object({
+  code: DeviceAuthorizationCodeSchema,
+  accessToken: z
+    .string()
+    .min(1)
+    .describe("Short-lived JWT used to authenticate requests"),
+  refreshToken: z
+    .string()
+    .min(1)
+    .describe("Long-lived opaque token used to rotate and issue new access tokens"),
+});
+
+export type DeviceAuthorizationCompleteRequest = z.infer<
+  typeof DeviceAuthorizationCompleteRequestSchema
+>;
+
+export const DeviceAuthorizationPollRequestSchema = z.object({
+  code: DeviceAuthorizationCodeSchema,
+});
+
+export type DeviceAuthorizationPollRequest = z.infer<
+  typeof DeviceAuthorizationPollRequestSchema
+>;
+
+export const DeviceAuthorizationPollResponseSchema = z.object({
+  accessToken: z
+    .string()
+    .min(1)
+    .describe("Short-lived JWT used to authenticate requests"),
+  refreshToken: z
+    .string()
+    .min(1)
+    .describe("Long-lived opaque token used to rotate and issue new access tokens"),
+});
+
+export type DeviceAuthorizationPollResponse = z.infer<
+  typeof DeviceAuthorizationPollResponseSchema
+>;

--- a/src/api/versions/v1/schemas/authentication-schemas.ts
+++ b/src/api/versions/v1/schemas/authentication-schemas.ts
@@ -130,14 +130,16 @@ export const DeviceAuthorizationCodeSchema = z
   )
   .describe(
     "Short-lived 16-character code printed by the bot for the pending authorization",
-  );
+  )
+  .openapi({ example: "A1B2C3D4E5F6G7H8" });
 
 export const DeviceAuthorizationMintResponseSchema = z.object({
   code: DeviceAuthorizationCodeSchema,
   expiresAt: z
     .string()
     .datetime()
-    .describe("Expiry timestamp (ISO 8601) of the issued code"),
+    .describe("Expiry timestamp (ISO 8601) of the issued code")
+    .openapi({ example: "2026-07-31T12:49:05.000Z" }),
 });
 
 export type DeviceAuthorizationMintResponse = z.infer<

--- a/src/api/versions/v1/services/device-authorization-codes-service.ts
+++ b/src/api/versions/v1/services/device-authorization-codes-service.ts
@@ -1,15 +1,16 @@
 import { inject, injectable } from "@needle-di/core";
 import { DatabaseService } from "../../../../core/services/database-service.ts";
-import { and, eq, gt, isNotNull, sql } from "drizzle-orm";
+import { and, eq, gt, isNotNull, isNull, sql } from "drizzle-orm";
 import { deviceAuthorizationCodesTable } from "../../../../db/schema.ts";
 import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
 import { ServerError } from "../models/server-error.ts";
 import { JWTService } from "../../../../core/services/jwt-service.ts";
+import { ENV_JWT_SECRET } from "../constants/environment-constants.ts";
 import { DEVICE_AUTHORIZATION_CODE_EXPIRATION_MS } from "../constants/authentication-constants.ts";
 
 const ENCRYPTION_IV_LENGTH = 12;
 const CODE_LENGTH = 16;
-const CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const CODE_ALPHABET = "ACDEFGHJKMNPQRTUVWXYZ234679";
 const REQUIRED_ROLE = "manager";
 
 export interface DeviceAuthorizationTokenPair {
@@ -87,6 +88,7 @@ export class DeviceAuthorizationCodesService {
         and(
           eq(deviceAuthorizationCodesTable.code, code),
           gt(deviceAuthorizationCodesTable.expiresAt, sql`now()`),
+          isNull(deviceAuthorizationCodesTable.encryptedTokens),
         ),
       )
       .returning({ code: deviceAuthorizationCodesTable.code });
@@ -103,43 +105,29 @@ export class DeviceAuthorizationCodesService {
   public async consume(
     code: string,
   ): Promise<DeviceAuthorizationTokenPair | null> {
-    const rows = await this.databaseService
-      .get()
-      .delete(deviceAuthorizationCodesTable)
-      .where(
-        and(
-          eq(deviceAuthorizationCodesTable.code, code),
-          gt(deviceAuthorizationCodesTable.expiresAt, sql`now()`),
-          isNotNull(deviceAuthorizationCodesTable.encryptedTokens),
-        ),
-      )
-      .returning({
-        encryptedTokens: deviceAuthorizationCodesTable.encryptedTokens,
-        expiresAt: deviceAuthorizationCodesTable.expiresAt,
-      });
+    return this.databaseService.get().transaction(async (tx) => {
+      const rows = await tx
+        .delete(deviceAuthorizationCodesTable)
+        .where(
+          and(
+            eq(deviceAuthorizationCodesTable.code, code),
+            gt(deviceAuthorizationCodesTable.expiresAt, sql`now()`),
+            isNotNull(deviceAuthorizationCodesTable.encryptedTokens),
+          ),
+        )
+        .returning({
+          encryptedTokens: deviceAuthorizationCodesTable.encryptedTokens,
+        });
 
-    if (rows.length === 0) return null;
+      if (rows.length === 0) return null;
 
-    const encryptedTokens = rows[0].encryptedTokens;
+      const encryptedTokens = rows[0].encryptedTokens;
 
-    if (encryptedTokens === null) return null;
+      if (encryptedTokens === null) return null;
 
-    try {
+      // Throwing rolls back the delete so a failed decrypt does not burn the code
       return await this.decryptTokens(encryptedTokens);
-    } catch (error) {
-      // Restore the row so a failed decrypt does not permanently burn the code
-      await this.databaseService
-        .get()
-        .insert(deviceAuthorizationCodesTable)
-        .values({
-          code,
-          encryptedTokens,
-          expiresAt: rows[0].expiresAt,
-        })
-        .onConflictDoNothing();
-
-      throw error;
-    }
+    });
   }
 
   private normalizeRoles(roles: unknown): string[] {
@@ -172,7 +160,7 @@ export class DeviceAuthorizationCodesService {
   private async getEncryptionKey(): Promise<CryptoKey> {
     if (this.encryptionKey !== null) return this.encryptionKey;
 
-    const jwtSecret = Deno.env.get("JWT_SECRET");
+    const jwtSecret = Deno.env.get(ENV_JWT_SECRET);
 
     if (jwtSecret === undefined) {
       throw new ServerError(
@@ -229,21 +217,21 @@ export class DeviceAuthorizationCodesService {
   private async decryptTokens(
     encoded: string,
   ): Promise<DeviceAuthorizationTokenPair> {
-    const key = await this.getEncryptionKey();
-    const data = decodeBase64(encoded);
-
-    if (data.byteLength <= ENCRYPTION_IV_LENGTH) {
-      throw new ServerError(
-        "INVALID_PAYLOAD",
-        "Encrypted payload too short",
-        400,
-      );
-    }
-
-    const iv = data.subarray(0, ENCRYPTION_IV_LENGTH);
-    const ciphertext = data.subarray(ENCRYPTION_IV_LENGTH);
-
     try {
+      const key = await this.getEncryptionKey();
+      const data = decodeBase64(encoded);
+
+      if (data.byteLength <= ENCRYPTION_IV_LENGTH) {
+        throw new ServerError(
+          "INVALID_PAYLOAD",
+          "Encrypted payload too short",
+          400,
+        );
+      }
+
+      const iv = data.subarray(0, ENCRYPTION_IV_LENGTH);
+      const ciphertext = data.subarray(ENCRYPTION_IV_LENGTH);
+
       const plaintext = await crypto.subtle.decrypt(
         { name: "AES-GCM", iv },
         key,
@@ -253,7 +241,9 @@ export class DeviceAuthorizationCodesService {
       return JSON.parse(
         new TextDecoder().decode(plaintext),
       ) as DeviceAuthorizationTokenPair;
-    } catch {
+    } catch (error) {
+      if (error instanceof ServerError) throw error;
+
       throw new ServerError(
         "DECRYPT_FAILED",
         "Invalid or corrupted encrypted payload",

--- a/src/api/versions/v1/services/device-authorization-codes-service.ts
+++ b/src/api/versions/v1/services/device-authorization-codes-service.ts
@@ -1,0 +1,264 @@
+import { inject, injectable } from "@needle-di/core";
+import { DatabaseService } from "../../../../core/services/database-service.ts";
+import { and, eq, gt, isNotNull, sql } from "drizzle-orm";
+import { deviceAuthorizationCodesTable } from "../../../../db/schema.ts";
+import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
+import { ServerError } from "../models/server-error.ts";
+import { JWTService } from "../../../../core/services/jwt-service.ts";
+import { DEVICE_AUTHORIZATION_CODE_EXPIRATION_MS } from "../constants/authentication-constants.ts";
+
+const ENCRYPTION_IV_LENGTH = 12;
+const CODE_LENGTH = 16;
+const CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const REQUIRED_ROLE = "manager";
+
+export interface DeviceAuthorizationTokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface DeviceAuthorizationCode {
+  code: string;
+  expiresAt: Date;
+}
+
+@injectable()
+export class DeviceAuthorizationCodesService {
+  private encryptionKey: CryptoKey | null = null;
+
+  constructor(
+    private databaseService = inject(DatabaseService),
+    private jwtService = inject(JWTService),
+  ) {}
+
+  public async create(): Promise<DeviceAuthorizationCode> {
+    const expiresAt = new Date(
+      Date.now() + DEVICE_AUTHORIZATION_CODE_EXPIRATION_MS,
+    );
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const code = this.generateCode();
+
+      const rows = await this.databaseService
+        .get()
+        .insert(deviceAuthorizationCodesTable)
+        .values({ code, expiresAt })
+        .onConflictDoNothing()
+        .returning({ code: deviceAuthorizationCodesTable.code });
+
+      if (rows.length > 0) {
+        return { code, expiresAt };
+      }
+    }
+
+    throw new ServerError(
+      "DEVICE_AUTHORIZATION_CODE_CREATION_FAILED",
+      "Failed to create device authorization code",
+      500,
+    );
+  }
+
+  public async save(
+    code: string,
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<void> {
+    const payload = await this.jwtService.verify(accessToken);
+    const roles = this.normalizeRoles(payload.roles);
+
+    if (!roles.includes(REQUIRED_ROLE)) {
+      throw new ServerError(
+        "NO_MANAGER_ROLE",
+        "Missing manager role",
+        403,
+      );
+    }
+
+    const encryptedTokens = await this.encryptTokens({
+      accessToken,
+      refreshToken,
+    });
+
+    const rows = await this.databaseService
+      .get()
+      .update(deviceAuthorizationCodesTable)
+      .set({ encryptedTokens })
+      .where(
+        and(
+          eq(deviceAuthorizationCodesTable.code, code),
+          gt(deviceAuthorizationCodesTable.expiresAt, sql`now()`),
+        ),
+      )
+      .returning({ code: deviceAuthorizationCodesTable.code });
+
+    if (rows.length === 0) {
+      throw new ServerError(
+        "DEVICE_AUTHORIZATION_CODE_NOT_FOUND",
+        "Device authorization code not found or expired",
+        404,
+      );
+    }
+  }
+
+  public async consume(
+    code: string,
+  ): Promise<DeviceAuthorizationTokenPair | null> {
+    const rows = await this.databaseService
+      .get()
+      .delete(deviceAuthorizationCodesTable)
+      .where(
+        and(
+          eq(deviceAuthorizationCodesTable.code, code),
+          gt(deviceAuthorizationCodesTable.expiresAt, sql`now()`),
+          isNotNull(deviceAuthorizationCodesTable.encryptedTokens),
+        ),
+      )
+      .returning({
+        encryptedTokens: deviceAuthorizationCodesTable.encryptedTokens,
+        expiresAt: deviceAuthorizationCodesTable.expiresAt,
+      });
+
+    if (rows.length === 0) return null;
+
+    const encryptedTokens = rows[0].encryptedTokens;
+
+    if (encryptedTokens === null) return null;
+
+    try {
+      return await this.decryptTokens(encryptedTokens);
+    } catch (error) {
+      // Restore the row so a failed decrypt does not permanently burn the code
+      await this.databaseService
+        .get()
+        .insert(deviceAuthorizationCodesTable)
+        .values({
+          code,
+          encryptedTokens,
+          expiresAt: rows[0].expiresAt,
+        })
+        .onConflictDoNothing();
+
+      throw error;
+    }
+  }
+
+  private normalizeRoles(roles: unknown): string[] {
+    if (!Array.isArray(roles)) return [];
+
+    return roles.filter((role): role is string => typeof role === "string");
+  }
+
+  private generateCode(): string {
+    const randomBytes = new Uint8Array(CODE_LENGTH);
+    const maxValid = 256 - (256 % CODE_ALPHABET.length);
+
+    let code = "";
+
+    while (code.length < CODE_LENGTH) {
+      crypto.getRandomValues(randomBytes);
+
+      for (const byte of randomBytes) {
+        if (byte >= maxValid) continue;
+
+        code += CODE_ALPHABET[byte % CODE_ALPHABET.length];
+
+        if (code.length === CODE_LENGTH) break;
+      }
+    }
+
+    return code;
+  }
+
+  private async getEncryptionKey(): Promise<CryptoKey> {
+    if (this.encryptionKey !== null) return this.encryptionKey;
+
+    const jwtSecret = Deno.env.get("JWT_SECRET");
+
+    if (jwtSecret === undefined) {
+      throw new ServerError(
+        "BAD_SERVER_CONFIGURATION",
+        "JWT_SECRET is not set in environment variables",
+        500,
+      );
+    }
+
+    const keyMaterial = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(jwtSecret),
+      "HKDF",
+      false,
+      ["deriveKey"],
+    );
+
+    this.encryptionKey = await crypto.subtle.deriveKey(
+      {
+        name: "HKDF",
+        hash: "SHA-256",
+        salt: new TextEncoder().encode("device-authorization"),
+        info: new TextEncoder().encode("device-authorization-tokens"),
+      },
+      keyMaterial,
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["encrypt", "decrypt"],
+    );
+
+    return this.encryptionKey;
+  }
+
+  private async encryptTokens(
+    pair: DeviceAuthorizationTokenPair,
+  ): Promise<string> {
+    const key = await this.getEncryptionKey();
+    const iv = crypto.getRandomValues(new Uint8Array(ENCRYPTION_IV_LENGTH));
+    const payload = new TextEncoder().encode(JSON.stringify(pair));
+
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      payload,
+    );
+
+    const result = new Uint8Array(iv.length + ciphertext.byteLength);
+    result.set(iv, 0);
+    result.set(new Uint8Array(ciphertext), iv.length);
+
+    return encodeBase64(result);
+  }
+
+  private async decryptTokens(
+    encoded: string,
+  ): Promise<DeviceAuthorizationTokenPair> {
+    const key = await this.getEncryptionKey();
+    const data = decodeBase64(encoded);
+
+    if (data.byteLength <= ENCRYPTION_IV_LENGTH) {
+      throw new ServerError(
+        "INVALID_PAYLOAD",
+        "Encrypted payload too short",
+        400,
+      );
+    }
+
+    const iv = data.subarray(0, ENCRYPTION_IV_LENGTH);
+    const ciphertext = data.subarray(ENCRYPTION_IV_LENGTH);
+
+    try {
+      const plaintext = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv },
+        key,
+        ciphertext,
+      );
+
+      return JSON.parse(
+        new TextDecoder().decode(plaintext),
+      ) as DeviceAuthorizationTokenPair;
+    } catch {
+      throw new ServerError(
+        "DECRYPT_FAILED",
+        "Invalid or corrupted encrypted payload",
+        400,
+      );
+    }
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,6 +15,7 @@ export { gameConfigurationTable } from "./tables/game-configuration-table.ts";
 export { authenticationChallengesTable } from "./tables/authentication-challenges-table.ts";
 export { userEncryptionKeysTable } from "./tables/user-encryption-keys-table.ts";
 export { refreshTokensTable } from "./tables/refresh-tokens-table.ts";
+export { deviceAuthorizationCodesTable } from "./tables/device-authorization-codes-table.ts";
 
 // Export RLS roles and helpers
 export * from "./rls.ts";

--- a/src/db/tables/device-authorization-codes-table.ts
+++ b/src/db/tables/device-authorization-codes-table.ts
@@ -4,6 +4,7 @@ import {
   text,
   timestamp,
   pgPolicy,
+  check,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import { authenticatedUserRole } from "../rls.ts";
@@ -19,6 +20,15 @@ export const deviceAuthorizationCodesTable = pgTable.withRLS(
       .notNull(),
   },
   (table) => [
+    check(
+      "device_authorization_codes_code_format",
+      sql`code ~ '^[A-Z0-9]{16}$'`,
+    ),
+    pgPolicy("device_authorization_codes_all_select", {
+      for: "select",
+      to: authenticatedUserRole,
+      using: sql`true`,
+    }),
     pgPolicy("device_authorization_codes_all_insert", {
       for: "insert",
       to: authenticatedUserRole,

--- a/src/db/tables/device-authorization-codes-table.ts
+++ b/src/db/tables/device-authorization-codes-table.ts
@@ -1,0 +1,44 @@
+import {
+  pgTable,
+  varchar,
+  text,
+  timestamp,
+  pgPolicy,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { authenticatedUserRole } from "../rls.ts";
+
+export const deviceAuthorizationCodesTable = pgTable.withRLS(
+  "device_authorization_codes",
+  {
+    code: varchar("code", { length: 16 }).primaryKey(),
+    encryptedTokens: text("encrypted_tokens"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    pgPolicy("device_authorization_codes_all_insert", {
+      for: "insert",
+      to: authenticatedUserRole,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("device_authorization_codes_all_update", {
+      for: "update",
+      to: authenticatedUserRole,
+      using: sql`true`,
+      withCheck: sql`true`,
+    }),
+    pgPolicy("device_authorization_codes_all_delete", {
+      for: "delete",
+      to: authenticatedUserRole,
+      using: sql`true`,
+    }),
+  ],
+);
+
+export type DeviceAuthorizationCodeEntity =
+  typeof deviceAuthorizationCodesTable.$inferSelect;
+export type DeviceAuthorizationCodeInsertEntity =
+  typeof deviceAuthorizationCodesTable.$inferInsert;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { DatabaseService } from "./core/services/database-service.ts";
 import { registerCleanupAuthenticationChallengesCron } from "../crons/cleanup-authentication-challenges-cron.ts";
 import { registerCleanupRefreshTokensCron } from "../crons/cleanup-refresh-tokens-cron.ts";
 import { registerCleanupUserSessionsCron } from "../crons/cleanup-user-sessions-cron.ts";
+import { registerCleanupDeviceAuthorizationCodesCron } from "../crons/cleanup-device-authorization-codes-cron.ts";
 
 const container = new Container();
 
@@ -13,6 +14,7 @@ databaseService.init();
 registerCleanupAuthenticationChallengesCron(databaseService);
 registerCleanupRefreshTokensCron(databaseService);
 registerCleanupUserSessionsCron(databaseService);
+registerCleanupDeviceAuthorizationCodesCron(databaseService);
 
 const httpService = container.get(HTTPService);
 await httpService.listen();

--- a/static/device-authorization/index.html
+++ b/static/device-authorization/index.html
@@ -12,9 +12,9 @@
       <h1>Sign in to the bot</h1>
       <p>Use a passkey with the <code>manager</code> role to authorize the bot.</p>
       <label for="code-input">Authorization code</label>
-      <input id="code-input" type="text" placeholder="XXXXXXXXXXXXXXXX" autocomplete="off" maxlength="16" />
+      <input id="code-input" type="text" placeholder="XXXXXXXXXXXXXXXX" autocomplete="off" autocapitalize="characters" inputmode="text" maxlength="16" />
       <button id="sign-in-button">Sign in with passkey</button>
-      <p id="status"></p>
+      <p id="status" role="status" aria-live="polite"></p>
     </dialog>
   </body>
 </html>

--- a/static/device-authorization/index.html
+++ b/static/device-authorization/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign in to the bot</title>
+    <link href="./styles/main.css" rel="stylesheet" />
+    <script defer type="module" src="./scripts/main.js"></script>
+  </head>
+  <body>
+    <dialog id="device-authorization-dialog">
+      <h1>Sign in to the bot</h1>
+      <p>Use a passkey with the <code>manager</code> role to authorize the bot.</p>
+      <label for="code-input">Authorization code</label>
+      <input id="code-input" type="text" placeholder="XXXXXXXXXXXXXXXX" autocomplete="off" maxlength="16" />
+      <button id="sign-in-button">Sign in with passkey</button>
+      <p id="status"></p>
+    </dialog>
+  </body>
+</html>

--- a/static/device-authorization/scripts/api-service.js
+++ b/static/device-authorization/scripts/api-service.js
@@ -5,6 +5,7 @@ export class APIService {
   static AUTHENTICATION_OPTIONS_ENDPOINT = `${this.AUTHENTICATION_ENDPOINT}/options`;
   static VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT = `${this.AUTHENTICATION_ENDPOINT}/response`;
   static DEVICE_AUTHORIZATION_COMPLETE_ENDPOINT = `${this.AUTHENTICATION_ENDPOINT}/device-authorization/complete`;
+  static REQUEST_TIMEOUT_MS = 10000;
 
   constructor() {
     this.baseURL = APIService.getBaseURL();
@@ -16,64 +17,61 @@ export class APIService {
   }
 
   static async throwAPIError(response) {
-    const errorResponse = await response.json();
-    const error = new Error(errorResponse.message);
-    error.code = errorResponse.code;
+    let errorResponse = null;
+
+    try {
+      errorResponse = await response.json();
+    } catch {
+      errorResponse = null;
+    }
+
+    const error = new Error(
+      errorResponse?.message ?? `Request failed with status ${response.status}`
+    );
+    error.code = errorResponse?.code ?? "UNKNOWN_ERROR";
+    error.status = response.status;
     throw error;
   }
 
-  async getAuthenticationOptions(authenticationOptionsRequest) {
-    const response = await fetch(
-      this.baseURL + APIService.AUTHENTICATION_OPTIONS_ENDPOINT,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(authenticationOptionsRequest),
-      }
-    );
+  async postJSON(endpoint, body) {
+    const response = await fetch(this.baseURL + endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(APIService.REQUEST_TIMEOUT_MS),
+    });
 
     if (response.ok === false) {
       await APIService.throwAPIError(response);
     }
+
+    return response;
+  }
+
+  async getAuthenticationOptions(authenticationOptionsRequest) {
+    const response = await this.postJSON(
+      APIService.AUTHENTICATION_OPTIONS_ENDPOINT,
+      authenticationOptionsRequest
+    );
 
     return response.json();
   }
 
   async verifyAuthenticationResponse(verifyAuthenticationRequest) {
-    const response = await fetch(
-      this.baseURL + APIService.VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(verifyAuthenticationRequest),
-      }
+    const response = await this.postJSON(
+      APIService.VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT,
+      verifyAuthenticationRequest
     );
-
-    if (response.ok === false) {
-      await APIService.throwAPIError(response);
-    }
 
     return response.json();
   }
 
   async completeDeviceAuthorization(deviceAuthorizationRequest) {
-    const response = await fetch(
-      this.baseURL + APIService.DEVICE_AUTHORIZATION_COMPLETE_ENDPOINT,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(deviceAuthorizationRequest),
-      }
+    await this.postJSON(
+      APIService.DEVICE_AUTHORIZATION_COMPLETE_ENDPOINT,
+      deviceAuthorizationRequest
     );
-
-    if (response.ok === false) {
-      await APIService.throwAPIError(response);
-    }
   }
 }

--- a/static/device-authorization/scripts/api-service.js
+++ b/static/device-authorization/scripts/api-service.js
@@ -1,0 +1,79 @@
+export class APIService {
+  static API_PATH = "/api";
+  static API_VERSION = "/v1";
+  static AUTHENTICATION_ENDPOINT = `/authentication`;
+  static AUTHENTICATION_OPTIONS_ENDPOINT = `${this.AUTHENTICATION_ENDPOINT}/options`;
+  static VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT = `${this.AUTHENTICATION_ENDPOINT}/response`;
+  static DEVICE_AUTHORIZATION_COMPLETE_ENDPOINT = `${this.AUTHENTICATION_ENDPOINT}/device-authorization/complete`;
+
+  constructor() {
+    this.baseURL = APIService.getBaseURL();
+  }
+
+  static getBaseURL() {
+    const { protocol, host } = self.location;
+    return `${protocol}//${host}${this.API_PATH}${this.API_VERSION}`;
+  }
+
+  static async throwAPIError(response) {
+    const errorResponse = await response.json();
+    const error = new Error(errorResponse.message);
+    error.code = errorResponse.code;
+    throw error;
+  }
+
+  async getAuthenticationOptions(authenticationOptionsRequest) {
+    const response = await fetch(
+      this.baseURL + APIService.AUTHENTICATION_OPTIONS_ENDPOINT,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(authenticationOptionsRequest),
+      }
+    );
+
+    if (response.ok === false) {
+      await APIService.throwAPIError(response);
+    }
+
+    return response.json();
+  }
+
+  async verifyAuthenticationResponse(verifyAuthenticationRequest) {
+    const response = await fetch(
+      this.baseURL + APIService.VERIFY_AUTHENTICATION_RESPONSE_ENDPOINT,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(verifyAuthenticationRequest),
+      }
+    );
+
+    if (response.ok === false) {
+      await APIService.throwAPIError(response);
+    }
+
+    return response.json();
+  }
+
+  async completeDeviceAuthorization(deviceAuthorizationRequest) {
+    const response = await fetch(
+      this.baseURL + APIService.DEVICE_AUTHORIZATION_COMPLETE_ENDPOINT,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(deviceAuthorizationRequest),
+      }
+    );
+
+    if (response.ok === false) {
+      await APIService.throwAPIError(response);
+    }
+  }
+}

--- a/static/device-authorization/scripts/credential-service.js
+++ b/static/device-authorization/scripts/credential-service.js
@@ -42,6 +42,11 @@ export class CredentialService {
       throw error;
     }
 
+    if (credential === null || credential === undefined) {
+      console.log("No credential returned");
+      return null;
+    }
+
     const verifyAuthenticationRequest = {
       transactionId,
       authenticationResponse: this.serializeCredential(credential),

--- a/static/device-authorization/scripts/credential-service.js
+++ b/static/device-authorization/scripts/credential-service.js
@@ -1,0 +1,109 @@
+import { APIService } from "./api-service.js";
+
+export class CredentialService {
+  constructor(apiService = new APIService()) {
+    this.apiService = apiService;
+  }
+
+  async getCredential() {
+    const transactionId = crypto.randomUUID();
+    const authenticationOptionsRequest = { transactionId };
+
+    const authenticationOptions =
+      await this.apiService.getAuthenticationOptions(
+        authenticationOptionsRequest
+      );
+
+    const publicKey = {
+      ...authenticationOptions,
+      challenge: this.base64UrlToArrayBuffer(authenticationOptions.challenge),
+      allowCredentials: authenticationOptions.allowCredentials?.map(
+        (credential) => ({
+          ...credential,
+          id: this.base64UrlToArrayBuffer(credential.id),
+        })
+      ),
+    };
+
+    let credential;
+
+    try {
+      credential = await navigator.credentials.get({ publicKey });
+    } catch (error) {
+      if (
+        error instanceof DOMException &&
+        (error.name === "AbortError" || error.name === "NotAllowedError")
+      ) {
+        console.log("User cancelled credential request");
+        return null;
+      }
+
+      console.error("Unexpected error during credential request:", error);
+      throw error;
+    }
+
+    const verifyAuthenticationRequest = {
+      transactionId,
+      authenticationResponse: this.serializeCredential(credential),
+    };
+
+    const response = await this.apiService.verifyAuthenticationResponse(
+      verifyAuthenticationRequest
+    );
+
+    this.handleAuthenticationResponse(response);
+  }
+
+  handleAuthenticationResponse(response) {
+    const event = new CustomEvent("authentication-success", {
+      detail: response,
+    });
+
+    document.dispatchEvent(event);
+
+    console.log("Authentication event dispatched");
+  }
+
+  arrayBufferToBase64Url(arrayBuffer) {
+    const bytes = new Uint8Array(arrayBuffer);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    const base64 = btoa(binary);
+    return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+
+  base64UrlToArrayBuffer(base64url) {
+    base64url = base64url.replace(/-/g, "+").replace(/_/g, "/");
+    base64url += "=".repeat((4 - (base64url.length % 4)) % 4);
+    const binary = atob(base64url);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  serializeCredential(credential) {
+    const { type, rawId, response } = credential;
+
+    return {
+      id: this.arrayBufferToBase64Url(rawId),
+      type,
+      rawId: this.arrayBufferToBase64Url(rawId),
+      response: {
+        clientDataJSON: this.arrayBufferToBase64Url(response.clientDataJSON),
+        authenticatorData: response.authenticatorData
+          ? this.arrayBufferToBase64Url(response.authenticatorData)
+          : null,
+        signature: response.signature
+          ? this.arrayBufferToBase64Url(response.signature)
+          : null,
+        userHandle: response.userHandle
+          ? this.arrayBufferToBase64Url(response.userHandle)
+          : null,
+      },
+    };
+  }
+}

--- a/static/device-authorization/scripts/main.js
+++ b/static/device-authorization/scripts/main.js
@@ -15,7 +15,7 @@ document.addEventListener("authentication-success", handleAuthenticationSuccess)
 dialogElement.showModal();
 
 async function handleSignIn() {
-  const code = codeInputElement.value.trim();
+  const code = codeInputElement.value.trim().toUpperCase();
   if (!code) {
     statusElement.textContent = "Enter the authorization code.";
     return;
@@ -38,7 +38,7 @@ async function handleSignIn() {
 }
 
 async function handleAuthenticationSuccess(event) {
-  const code = codeInputElement.value.trim();
+  const code = codeInputElement.value.trim().toUpperCase();
   statusElement.textContent = "Verifying…";
 
   try {

--- a/static/device-authorization/scripts/main.js
+++ b/static/device-authorization/scripts/main.js
@@ -1,0 +1,60 @@
+import { CredentialService } from "./credential-service.js";
+import { APIService } from "./api-service.js";
+
+const credentialService = new CredentialService();
+const apiService = new APIService();
+
+const dialogElement = document.getElementById("device-authorization-dialog");
+const codeInputElement = document.getElementById("code-input");
+const signInButtonElement = document.getElementById("sign-in-button");
+const statusElement = document.getElementById("status");
+
+signInButtonElement.addEventListener("click", handleSignIn);
+document.addEventListener("authentication-success", handleAuthenticationSuccess);
+
+dialogElement.showModal();
+
+async function handleSignIn() {
+  const code = codeInputElement.value.trim();
+  if (!code) {
+    statusElement.textContent = "Enter the authorization code.";
+    return;
+  }
+
+  signInButtonElement.disabled = true;
+  statusElement.textContent = "Waiting for your passkey…";
+
+  try {
+    const result = await credentialService.getCredential();
+
+    if (result === null) {
+      statusElement.textContent = "Sign-in cancelled.";
+      enableSignIn();
+    }
+  } catch (error) {
+    statusElement.textContent = "Error: " + (error.message || String(error));
+    enableSignIn();
+  }
+}
+
+async function handleAuthenticationSuccess(event) {
+  const code = codeInputElement.value.trim();
+  statusElement.textContent = "Verifying…";
+
+  try {
+    await apiService.completeDeviceAuthorization({
+      code,
+      accessToken: event.detail.accessToken,
+      refreshToken: event.detail.refreshToken,
+    });
+
+    statusElement.textContent = "Signed in! You can close this tab.";
+  } catch (error) {
+    statusElement.textContent = "Error: " + (error.message || String(error));
+    enableSignIn();
+  }
+}
+
+function enableSignIn() {
+  signInButtonElement.disabled = false;
+}

--- a/static/device-authorization/styles/main.css
+++ b/static/device-authorization/styles/main.css
@@ -3,12 +3,12 @@ body {
   width: 100%;
   height: 100%;
   margin: 0;
-  overflow: hidden;
+  overflow: auto;
   background: #1e1e20;
   display: flex;
   justify-content: center;
   align-items: center;
-  touch-action: none;
+  touch-action: auto;
   font-family: system-ui;
   font-size: 16px;
 }
@@ -18,7 +18,8 @@ dialog {
   padding: 20px;
   border-radius: 6px;
   text-align: center;
-  top: -170px;
+  max-height: calc(100dvh - 2rem);
+  overflow: auto;
   background: #fff;
   opacity: 0;
   transform: scale(0.9);

--- a/static/device-authorization/styles/main.css
+++ b/static/device-authorization/styles/main.css
@@ -1,0 +1,74 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: #1e1e20;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  touch-action: none;
+  font-family: system-ui;
+  font-size: 16px;
+}
+
+dialog {
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 20px;
+  border-radius: 6px;
+  text-align: center;
+  top: -170px;
+  background: #fff;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+}
+
+dialog[open] {
+  opacity: 1;
+  transform: scale(1);
+}
+
+dialog h1 {
+  margin-top: 0;
+}
+
+input[type="text"] {
+  width: 100%;
+  font-size: 16px;
+  box-sizing: border-box;
+  border: 2px solid #000;
+  border-radius: 8px;
+  text-indent: 2px;
+  margin-bottom: 14px;
+  padding: 6px 8px;
+}
+
+button {
+  width: 100%;
+  padding: 10px 0;
+  border: 0;
+  background: #4a90e2;
+  border-radius: 20px;
+  font-family: system-ui;
+  font-weight: bold;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #7ed321;
+}
+
+button:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+#status {
+  min-height: 1.25em;
+  margin: 14px 0 0;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary

Adds a device authorization flow so the bot can obtain user tokens for an interactive device (e.g., a console/PS3 client) via a one-time code:

1. **Mint** — `POST /api/v1/authentication/device-authorization` issues a server-generated 16-char `[A-Z0-9]` code with an expiry anchored to issuance time (10 min). The bot shows the code to the user.
2. **Complete** — the user signs in with a passkey on the served static page (`/device-authorization`), which stores the resulting token pair against the code via `POST .../device-authorization/complete`.
3. **Poll** — the bot retrieves and consumes the token pair via `POST .../device-authorization/poll` (single-use, delete-and-returning).
4. **Cleanup** — hourly `Deno.cron` deletes expired codes.

## Key design points

- Codes are server-minted (`device-authorization-codes-service.ts`), so only issued codes can be completed and expiry is enforced from generation.
- Tokens are encrypted at rest (AES-GCM, key derived from `JWT_SECRET`) and stored in the new `device_authorization_codes` table with RLS (insert/update/delete policies for `authenticated_user`).
- `complete` validates the request origin against `RP_ALLOWED_ORIGINS` and requires the signing user to have the `manager` role (403 otherwise).
- `poll` skips rows without tokens and restores the row on decrypt failure so a code isn't burned by a transient error.
- Schema enforces `^[A-Z0-9]{16}$` for codes.

## Files

- New: `device-authorization-codes-service.ts`, `device-authorization-codes-table.ts`, `cleanup-device-authorization-codes-cron.ts`, static page + scripts, 2 Drizzle migrations.
- Modified: authentication router (3 new/updated routes), schemas, constants, `schema.ts`, `main.ts`.

## Note for the bot

The bot must call the mint endpoint instead of generating codes itself, and use the returned `expiresAt` as its polling window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added device authorization sign-in using a 16-character code and passkey authentication.
  - Added a dedicated device authorization page with validation, status updates, and error handling.
  - Added secure token exchange and one-time code consumption through new authentication endpoints.
  - Authorization codes expire after 10 minutes and are automatically cleaned up hourly.
- **Security**
  - Added encrypted token storage and access controls for device authorization data.
- **Style**
  - Added responsive layout, dialog transitions, and button states for the device authorization experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->