### PR TITLE
feat: change bot token endpoint to POST with botId in body

### DIFF
--- a/src/api/versions/v1/routers/management/management-bot-router.ts
+++ b/src/api/versions/v1/routers/management/management-bot-router.ts
@@ -9,6 +9,7 @@ import {
   GetBotRolesResponseSchema,
   GetBotsQuerySchema,
   GetBotsResponseSchema,
+  GetBotTokenRequestSchema,
   GetBotTokenResponseSchema,
   RemoveBotRoleRequestSchema,
   UpdateBotRequestSchema,
@@ -212,19 +213,20 @@ export class ManagementBotRouter {
   private registerGetBotTokenRoute(): void {
     this.app.openapi(
       createRoute({
-        method: "get",
-        path: "/:botId/token",
+        method: "post",
+        path: "/token",
         summary: "Get token",
         description:
           "Mints a long-lived JWT for the bot reflecting its current roles",
         tags: ["Bots"],
         request: {
-          params: z.object({
-            botId: z
-              .string()
-              .uuid()
-              .describe("The bot ID to mint a token for"),
-          }),
+          body: {
+            content: {
+              "application/json": {
+                schema: GetBotTokenRequestSchema,
+              },
+            },
+          },
         },
         responses: {
           200: {
@@ -242,7 +244,7 @@ export class ManagementBotRouter {
         },
       }),
       async (c) => {
-        const botId = c.req.param("botId");
+        const { botId } = c.req.valid("json");
         const requesterUserId = c.get("userId") as string;
 
         const response = await this.botManagementService.getBotToken(

--- a/src/api/versions/v1/schemas/management-bot-schemas.ts
+++ b/src/api/versions/v1/schemas/management-bot-schemas.ts
@@ -90,6 +90,16 @@ export const GetBotTokenResponseSchema = z.object({
 
 export type GetBotTokenResponse = z.infer<typeof GetBotTokenResponseSchema>;
 
+export const GetBotTokenRequestSchema = z.object({
+  botId: z
+    .string()
+    .uuid()
+    .describe("The bot ID to mint a token for")
+    .openapi({ example: "00000000-0000-0000-0000-000000000000" }),
+});
+
+export type GetBotTokenRequest = z.infer<typeof GetBotTokenRequestSchema>;
+
 export const AddBotRoleRequestSchema = z.object({
   roleName: z
     .string()


### PR DESCRIPTION
Changes the GET /api/v1/bots/:botId/token endpoint to POST /api/v1/bots/token with botId sent in the JSON request body.