### PR TITLE
feat: management endpoints to list and update users

### DIFF
--- a/drizzle/20260805214922_light_morbius/migration.sql
+++ b/drizzle/20260805214922_light_morbius/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "users" ADD COLUMN "updated_at" timestamp with time zone;--> statement-breakpoint
+CREATE POLICY "bot_roles_insert_own" ON "bot_roles" AS PERMISSIVE FOR INSERT TO "authenticated_user" WITH CHECK ((current_setting('app.user_id', true)::uuid = (SELECT "bots"."created_by" FROM "bots" WHERE "bots"."id" = "bot_roles"."bot_id")));--> statement-breakpoint
+CREATE POLICY "bot_roles_delete_own" ON "bot_roles" AS PERMISSIVE FOR DELETE TO "authenticated_user" USING ((current_setting('app.user_id', true)::uuid = (SELECT "bots"."created_by" FROM "bots" WHERE "bots"."id" = "bot_roles"."bot_id")));

--- a/drizzle/20260805214922_light_morbius/snapshot.json
+++ b/drizzle/20260805214922_light_morbius/snapshot.json
@@ -1,0 +1,2468 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "590c19b1-3dce-4c4f-9e8b-37ed7bfef5bb",
+  "prevIds": [
+    "fc88e3d1-ab73-4637-9c03-d5368feac7f5"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "authentication_challenges",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "blocked_words",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "bot_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "bots",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "game_configuration",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "match_users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "matches",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "refresh_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_messages",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "server_signature_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_bans",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_credentials",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_encryption_keys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_reports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_scores",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "user_sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "blocked_words_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "word",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "bot_roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "game_configuration"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "match_users_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "match_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "matches_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "host_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "total_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "available_slots",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "ping_median_milliseconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attributes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "server_messages_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_messages"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "private_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_bans_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backup_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transports",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_reports_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reporter_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reported_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "varchar(500)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "automatic",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_roles_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": {
+        "type": "always",
+        "name": "user_scores_id_seq",
+        "increment": "1",
+        "startWith": "1",
+        "minValue": "1",
+        "maxValue": "2147483647",
+        "cache": 1,
+        "cycle": false
+      },
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_score",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar(44)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "inet",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_ip",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "country",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "token_version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lower(\"word\")",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "unique_lower_word",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "blocked_words"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "match_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_match_id_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "match_users_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "bot_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "bots",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "bot_roles_bot_id_bots_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "role_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "roles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "bot_roles_role_id_roles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "bots_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "match_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "matches",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_match_id_matches_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "match_users_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "match_users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "matches_host_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "matches"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "refresh_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_bans_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_credentials_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_encryption_keys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reporter_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reporter_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "reported_user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_reports_reported_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "role_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "roles",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_roles_role_id_roles_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_scores_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_scores"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "user_sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "authentication_challenges_pkey",
+      "schema": "public",
+      "table": "authentication_challenges",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "blocked_words_pkey",
+      "schema": "public",
+      "table": "blocked_words",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "bot_roles_pkey",
+      "schema": "public",
+      "table": "bot_roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "bots_pkey",
+      "schema": "public",
+      "table": "bots",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "game_configuration_pkey",
+      "schema": "public",
+      "table": "game_configuration",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "match_users_pkey",
+      "schema": "public",
+      "table": "match_users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "matches_pkey",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "token_hash"
+      ],
+      "nameExplicit": false,
+      "name": "refresh_tokens_pkey",
+      "schema": "public",
+      "table": "refresh_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "roles_pkey",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_messages_pkey",
+      "schema": "public",
+      "table": "server_messages",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "server_signature_keys_pkey",
+      "schema": "public",
+      "table": "server_signature_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_bans_pkey",
+      "schema": "public",
+      "table": "user_bans",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_credentials_pkey",
+      "schema": "public",
+      "table": "user_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_encryption_keys_pkey",
+      "schema": "public",
+      "table": "user_encryption_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_reports_pkey",
+      "schema": "public",
+      "table": "user_reports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_roles_pkey",
+      "schema": "public",
+      "table": "user_roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_scores_pkey",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_sessions_pkey",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "transaction_id",
+        "type"
+      ],
+      "nullsNotDistinct": false,
+      "name": "authentication_challenges_transaction_id_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "bot_id",
+        "role_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "bot_roles_bot_id_role_id_idx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "user_id",
+        "role_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_roles_user_id_role_id_idx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "bots_name_key",
+      "schema": "public",
+      "table": "bots",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "host_user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "matches_host_user_id_key",
+      "schema": "public",
+      "table": "matches",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "roles_name_key",
+      "schema": "public",
+      "table": "roles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_scores_user_id_key",
+      "schema": "public",
+      "table": "user_scores",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_sessions_token_key",
+      "schema": "public",
+      "table": "user_sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "display_name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_display_name_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"id\" = 1",
+      "name": "server_signature_keys_singleton",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "server_signature_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "authentication_challenges_all_insert",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_select",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "authentication_challenges_all_delete",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "authentication_challenges"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = (SELECT \"bots\".\"created_by\" FROM \"bots\" WHERE \"bots\".\"id\" = \"bot_roles\".\"bot_id\"))",
+      "withCheck": null,
+      "name": "bot_roles_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = (SELECT \"bots\".\"created_by\" FROM \"bots\" WHERE \"bots\".\"id\" = \"bot_roles\".\"bot_id\"))",
+      "name": "bot_roles_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = (SELECT \"bots\".\"created_by\" FROM \"bots\" WHERE \"bots\".\"id\" = \"bot_roles\".\"bot_id\"))",
+      "withCheck": null,
+      "name": "bot_roles_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bot_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"bots\".\"created_by\")",
+      "withCheck": null,
+      "name": "bots_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"bots\".\"created_by\")",
+      "name": "bots_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"bots\".\"created_by\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"bots\".\"created_by\")",
+      "name": "bots_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"bots\".\"created_by\")",
+      "withCheck": null,
+      "name": "bots_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "bots"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "name": "refresh_tokens_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"refresh_tokens\".\"user_id\")",
+      "withCheck": null,
+      "name": "refresh_tokens_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "refresh_tokens"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_bans\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_bans_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_bans"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": null,
+      "name": "user_credentials_select_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\")",
+      "withCheck": "(current_setting('app.credential_id', true) = \"user_credentials\".\"id\") AND (current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "name": "user_credentials_update_by_credential",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_credentials\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_credentials_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "name": "user_encryption_keys_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_encryption_keys\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_encryption_keys_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_encryption_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_roles\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_roles_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_roles"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": null,
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_insert_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "name": "user_sessions_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"user_sessions\".\"user_id\")",
+      "withCheck": null,
+      "name": "user_sessions_delete_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "user_sessions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": null,
+      "name": "users_select_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "authenticated_user"
+      ],
+      "using": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "withCheck": "(current_setting('app.user_id', true)::uuid = \"users\".\"id\")",
+      "name": "users_update_own",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "users"
+    }
+  ],
+  "renames": []
+}

--- a/src/api/versions/v1/routers/management-router.ts
+++ b/src/api/versions/v1/routers/management-router.ts
@@ -10,6 +10,7 @@ import { ManagementVersionRouter } from "./management/management-version-router.
 import { ManagementTextModerationRouter } from "./management/management-text-moderation-router.ts";
 import { ManagementUserRolesRouter } from "./management/management-user-roles-router.ts";
 import { ManagementBotRouter } from "./management/management-bot-router.ts";
+import { ManagementUsersRouter } from "./management/management-users-router.ts";
 
 @injectable()
 export class V1ManagementRouter {
@@ -27,6 +28,7 @@ export class V1ManagementRouter {
     private textModerationRouter = inject(ManagementTextModerationRouter),
     private userRolesRouter = inject(ManagementUserRolesRouter),
     private botRouter = inject(ManagementBotRouter),
+    private usersRouter = inject(ManagementUsersRouter),
   ) {
     this.app = new OpenAPIHono();
     this.setMiddlewares();
@@ -52,11 +54,12 @@ export class V1ManagementRouter {
 
   private setRoutes(): void {
     this.app.route("/game-version", this.versionRouter.getRouter());
-    this.app.route("/user-roles", this.userRolesRouter.getRouter());
-    this.app.route("/text-moderation", this.textModerationRouter.getRouter());
     this.app.route("/game-configuration", this.configurationRouter.getRouter());
     this.app.route("/server-messages", this.serverMessagesRouter.getRouter());
     this.app.route("/server-notification", this.notificationRouter.getRouter());
+    this.app.route("/users", this.usersRouter.getRouter());
+    this.app.route("/user-roles", this.userRolesRouter.getRouter());
     this.app.route("/bots", this.botRouter.getRouter());
+    this.app.route("/text-moderation", this.textModerationRouter.getRouter());
   }
 }

--- a/src/api/versions/v1/routers/management/management-users-router.ts
+++ b/src/api/versions/v1/routers/management/management-users-router.ts
@@ -1,0 +1,106 @@
+import { inject, injectable } from "@needle-di/core";
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { UsersService } from "../../services/users-service.ts";
+import {
+  GetUsersQuerySchema,
+  GetUsersResponseSchema,
+  UpdateUserRequestSchema,
+} from "../../schemas/users-schemas.ts";
+import { ServerResponse } from "../../models/server-response.ts";
+
+@injectable()
+export class ManagementUsersRouter {
+  private app: OpenAPIHono;
+
+  constructor(private usersService = inject(UsersService)) {
+    this.app = new OpenAPIHono();
+    this.setRoutes();
+  }
+
+  public getRouter(): OpenAPIHono {
+    return this.app;
+  }
+
+  private setRoutes(): void {
+    this.registerGetUsersRoute();
+    this.registerUpdateUserRoute();
+  }
+
+  private registerGetUsersRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "get",
+        path: "/",
+        summary: "Get users",
+        description: "Retrieves all users with pagination",
+        tags: ["Users"],
+        request: {
+          query: GetUsersQuerySchema,
+        },
+        responses: {
+          200: {
+            description: "Responds with users data",
+            content: {
+              "application/json": {
+                schema: GetUsersResponseSchema,
+              },
+            },
+          },
+          ...ServerResponse.BadRequest,
+          ...ServerResponse.Unauthorized,
+          ...ServerResponse.Forbidden,
+        },
+      }),
+      async (c) => {
+        const { cursor, limit } = c.req.valid("query");
+
+        const response = await this.usersService.list({ cursor, limit });
+
+        return c.json(response, 200);
+      },
+    );
+  }
+
+  private registerUpdateUserRoute(): void {
+    this.app.openapi(
+      createRoute({
+        method: "put",
+        path: "/:userId",
+        summary: "Update user",
+        description: "Updates the display name of a user",
+        tags: ["Users"],
+        request: {
+          params: z.object({
+            userId: z
+              .string()
+              .uuid()
+              .describe("The ID of the user to update"),
+          }),
+          body: {
+            content: {
+              "application/json": {
+                schema: UpdateUserRequestSchema,
+              },
+            },
+          },
+        },
+        responses: {
+          ...ServerResponse.NoContent,
+          ...ServerResponse.BadRequest,
+          ...ServerResponse.Unauthorized,
+          ...ServerResponse.Forbidden,
+          ...ServerResponse.NotFound,
+          ...ServerResponse.Conflict,
+        },
+      }),
+      async (c) => {
+        const userId = c.req.param("userId");
+        const { displayName } = c.req.valid("json");
+
+        await this.usersService.updateUser(userId, displayName);
+
+        return c.body(null, 204);
+      },
+    );
+  }
+}

--- a/src/api/versions/v1/schemas/users-schemas.ts
+++ b/src/api/versions/v1/schemas/users-schemas.ts
@@ -1,0 +1,48 @@
+import { z } from "@hono/zod-openapi";
+import {
+  StringPaginatedResponseSchema,
+  StringPaginationSchema,
+} from "./pagination-schemas.ts";
+
+export const UserResponseSchema = z.object({
+  id: z.string().uuid().describe("The user ID").openapi({
+    example: "6f9619ff-8b86-d011-b42d-00c04fc964ff",
+  }),
+  displayName: z
+    .string()
+    .max(16)
+    .describe("The user display name")
+    .openapi({ example: "JohnDoe" }),
+  createdAt: z
+    .string()
+    .describe("The user created timestamp")
+    .openapi({ example: "2026-08-05T12:00:00.000Z" }),
+  updatedAt: z
+    .string()
+    .nullable()
+    .describe("The user last updated timestamp")
+    .openapi({ example: "2026-08-05T12:00:00.000Z" }),
+});
+
+export type UserResponse = z.infer<typeof UserResponseSchema>;
+
+export const GetUsersQuerySchema = StringPaginationSchema;
+
+export type GetUsersQuery = z.infer<typeof StringPaginationSchema>;
+
+export const GetUsersResponseSchema = StringPaginatedResponseSchema(
+  UserResponseSchema,
+);
+
+export type GetUsersResponse = z.infer<typeof GetUsersResponseSchema>;
+
+export const UpdateUserRequestSchema = z.object({
+  displayName: z
+    .string()
+    .min(1)
+    .max(16)
+    .describe("The new user display name")
+    .openapi({ example: "JohnDoe" }),
+});
+
+export type UpdateUserRequest = z.infer<typeof UpdateUserRequestSchema>;

--- a/src/api/versions/v1/services/registration-service.ts
+++ b/src/api/versions/v1/services/registration-service.ts
@@ -240,6 +240,7 @@ export class RegistrationService {
       displayName: registrationOptions.user.name,
       tokenVersion: 0,
       createdAt: new Date(),
+      updatedAt: null,
     };
   }
 

--- a/src/api/versions/v1/services/users-service.ts
+++ b/src/api/versions/v1/services/users-service.ts
@@ -6,12 +6,108 @@ import {
   userRolesTable,
   usersTable,
 } from "../../../../db/schema.ts";
-import { eq } from "drizzle-orm";
+import { and, desc, eq, lt, ne } from "drizzle-orm";
+import type { StringPaginationParams } from "../schemas/pagination-schemas.ts";
+import type { GetUsersResponse, UserResponse } from "../schemas/users-schemas.ts";
 import type { UserEntity } from "../../../../db/tables/users-table.ts";
 
 @injectable()
 export class UsersService {
   constructor(private databaseService = inject(DatabaseService)) {}
+
+  public async list(
+    params: StringPaginationParams,
+  ): Promise<GetUsersResponse> {
+    const { cursor, limit = 20 } = params;
+    const db = this.databaseService.get();
+
+    try {
+      const conditions = cursor
+        ? [lt(usersTable.id, cursor)]
+        : undefined;
+
+      const query = db
+        .select()
+        .from(usersTable)
+        .where(conditions ? conditions[0] : undefined)
+        .orderBy(desc(usersTable.id))
+        .limit(limit + 1);
+
+      const users = await query;
+
+      const hasNextPage = users.length > limit;
+      const results = users.slice(0, limit).map((user) => ({
+        id: user.id,
+        displayName: user.displayName,
+        createdAt: user.createdAt.toISOString(),
+        updatedAt: user.updatedAt?.toISOString() || null,
+      })) as UserResponse[];
+
+      return {
+        results,
+        nextCursor: hasNextPage && results.length > 0
+          ? results[results.length - 1].id
+          : undefined,
+        hasMore: hasNextPage,
+      };
+    } catch (error) {
+      console.error("Failed to query users:", error);
+      throw new ServerError("DATABASE_ERROR", "Failed to retrieve users", 500);
+    }
+  }
+
+  public async updateUser(
+    userId: string,
+    displayName: string,
+  ): Promise<void> {
+    const db = this.databaseService.get();
+
+    try {
+      await db.transaction(async (tx) => {
+        // Check if user exists and lock the row to prevent race conditions
+        const users = await tx
+          .select()
+          .from(usersTable)
+          .where(eq(usersTable.id, userId))
+          .for("update")
+          .limit(1);
+
+        if (users.length === 0) {
+          throw new ServerError("USER_NOT_FOUND", "User not found", 404);
+        }
+
+        // Check for display name conflict with other users
+        const conflicting = await tx
+          .select({ id: usersTable.id })
+          .from(usersTable)
+          .where(
+            and(
+              eq(usersTable.displayName, displayName),
+              ne(usersTable.id, userId),
+            ),
+          )
+          .limit(1);
+
+        if (conflicting.length > 0) {
+          throw new ServerError(
+            "DISPLAY_NAME_TAKEN",
+            "Display name is already in use by another user",
+            409,
+          );
+        }
+
+        // Update the user display name and refresh the updated timestamp
+        await tx
+          .update(usersTable)
+          .set({ displayName, updatedAt: new Date() })
+          .where(eq(usersTable.id, userId));
+      });
+    } catch (error) {
+      if (error instanceof ServerError) throw error;
+      console.error("Failed to update user:", error);
+      throw new ServerError("DATABASE_ERROR", "Failed to update user", 500);
+    }
+  }
 
   public async getByIdOrThrow(userId: string): Promise<UserEntity> {
     try {

--- a/src/db/tables/users-table.ts
+++ b/src/db/tables/users-table.ts
@@ -17,6 +17,7 @@ export const usersTable = pgTable.withRLS(
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }),
   },
   (table) => [
     // Users can read their own user record


### PR DESCRIPTION
## Summary

Adds management endpoints to list users (cursor-paginated) and update a user's display name.

## Changes

- Add `GET /management/users` with cursor pagination via `UsersService.list`
- Add `PUT /management/users/:userId` to update a user's display name (`UsersService.updateUser`)
- Add `updated_at` column to the `users` table and related schemas
- Add migration for the new column and pending bot_roles policies
- Wire up `ManagementUsersRouter` in the management router

## Verification

- `deno task check` passes