### PR TITLE
fix: remove duplicate bot_roles policy creation in migration

### DIFF
--- a/drizzle/20260805214922_light_morbius/migration.sql
+++ b/drizzle/20260805214922_light_morbius/migration.sql
@@ -1,3 +1,1 @@
-ALTER TABLE "users" ADD COLUMN "updated_at" timestamp with time zone;--> statement-breakpoint
-CREATE POLICY "bot_roles_insert_own" ON "bot_roles" AS PERMISSIVE FOR INSERT TO "authenticated_user" WITH CHECK ((current_setting('app.user_id', true)::uuid = (SELECT "bots"."created_by" FROM "bots" WHERE "bots"."id" = "bot_roles"."bot_id")));--> statement-breakpoint
-CREATE POLICY "bot_roles_delete_own" ON "bot_roles" AS PERMISSIVE FOR DELETE TO "authenticated_user" USING ((current_setting('app.user_id', true)::uuid = (SELECT "bots"."created_by" FROM "bots" WHERE "bots"."id" = "bot_roles"."bot_id")));
+ALTER TABLE "users" ADD COLUMN "updated_at" timestamp with time zone;


### PR DESCRIPTION
The `20260805214922_light_morbius` migration re-created the `bot_roles_insert_own` and `bot_roles_delete_own` policies that already existed from the `20260805155102_sticky_reaper` migration, causing deployments to fail with error `42710 (policy already exists)`.

Removed the duplicate `CREATE POLICY` statements, leaving only the pending `users.updated_at` column change. The failed transaction was rolled back, so this migration will now apply cleanly on next `deno task migrate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an `updated_at` timestamp to user records.
  * Removed obsolete bot-role access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->