### PR TITLE
feat: rename /alert to /notification and remove embed titles

### DIFF
--- a/src/api/versions/v1/constants/discord-command-constants.ts
+++ b/src/api/versions/v1/constants/discord-command-constants.ts
@@ -13,12 +13,12 @@ const INTEGER = DiscordCommandOptionType.Integer;
 
 export const DISCORD_SLASH_COMMANDS: DiscordSlashCommandPayload[] = [
   {
-    name: "alert",
-    description: "Send a flash news alert to players in-game",
+    name: "notification",
+    description: "Send a notification to players in-game",
     options: [
       {
         name: "text",
-        description: "The alert message to broadcast",
+        description: "The notification message to broadcast",
         type: STRING,
         required: true,
       },

--- a/src/api/versions/v1/constants/discord-command-constants.ts
+++ b/src/api/versions/v1/constants/discord-command-constants.ts
@@ -85,6 +85,19 @@ export const DISCORD_SLASH_COMMANDS: DiscordSlashCommandPayload[] = [
       },
       {
         type: SUB_COMMAND,
+        name: "view",
+        description: "View a news item's full details",
+        options: [
+          {
+            name: "id",
+            description: "News ID",
+            type: INTEGER,
+            required: true,
+          },
+        ],
+      },
+      {
+        type: SUB_COMMAND,
         name: "delete",
         description: "Delete a news item",
         options: [

--- a/src/api/versions/v1/schemas/discord-interaction-schemas.ts
+++ b/src/api/versions/v1/schemas/discord-interaction-schemas.ts
@@ -61,6 +61,7 @@ export const DiscordInteractionResponseSchema = z.object({
     .describe("The interaction response type"),
   data: z
     .object({
+      content: z.string().optional().describe("The message content"),
       embeds: z
         .array(
           z.object({

--- a/src/api/versions/v1/services/discord-command-service.ts
+++ b/src/api/versions/v1/services/discord-command-service.ts
@@ -230,7 +230,9 @@ export class DiscordCommandService {
             },
             {
               name: "Updated",
-              value: this.formatTimestamp(message.updatedAt),
+              value: this.formatTimestamp(
+                message.updatedAt ?? message.createdAt,
+              ),
               inline: true,
             },
           ]);

--- a/src/api/versions/v1/services/discord-command-service.ts
+++ b/src/api/versions/v1/services/discord-command-service.ts
@@ -56,8 +56,8 @@ export class DiscordCommandService {
 
     try {
       switch (name) {
-        case "alert":
-          return this.handleAlert(interaction);
+        case "notification":
+          return this.handleNotification(interaction);
         case "news":
           return await this.handleNews(interaction);
         default:
@@ -97,7 +97,7 @@ export class DiscordCommandService {
     ).split(",").map((name) => name.trim()).filter(Boolean);
   }
 
-  private handleAlert(
+  private handleNotification(
     interaction: DiscordInteractionPayload,
   ): DiscordInteractionResponse {
     const values = this.optionValues(interaction.data?.options);
@@ -107,7 +107,10 @@ export class DiscordCommandService {
     );
 
     if (!text) {
-      return this.errorResponse("Alert", "The alert text cannot be empty.");
+      return this.errorResponse(
+        "Notification",
+        "The notification text cannot be empty.",
+      );
     }
 
     try {
@@ -116,13 +119,13 @@ export class DiscordCommandService {
         text,
       );
       return this.successResponse(
-        "Alert sent",
-        `Flash news pushed to **${channel}** players.\n\n${text}`,
+        "Notification sent",
+        `Notification pushed to **${channel}** players.\n\n${text}`,
       );
     } catch (e) {
-      console.error("discord alert failed:", e);
+      console.error("discord notification failed:", e);
       return this.errorResponse(
-        "Alert failed",
+        "Notification failed",
         DiscordCommandService.GENERIC_ERROR_MESSAGE,
       );
     }
@@ -303,40 +306,41 @@ export class DiscordCommandService {
   }
 
   private successResponse(
-    title: string,
+    heading: string,
     description?: string,
     fields?: DiscordEmbed["fields"],
   ): DiscordInteractionResponse {
     return this.embed({
-      title,
-      description,
+      description: this.withHeading(heading, description),
       color: EMBED_COLORS.success,
       fields,
     });
   }
 
   private infoResponse(
-    title: string,
+    heading: string,
     description?: string,
     fields?: DiscordEmbed["fields"],
   ): DiscordInteractionResponse {
     return this.embed({
-      title,
-      description,
+      description: this.withHeading(heading, description),
       color: EMBED_COLORS.info,
       fields,
     });
   }
 
   private errorResponse(
-    title: string,
+    heading: string,
     description?: string,
   ): DiscordInteractionResponse {
     return this.embed({
-      title,
-      description,
+      description: this.withHeading(heading, description),
       color: EMBED_COLORS.error,
     });
+  }
+
+  private withHeading(heading: string, description?: string): string {
+    return description ? `**${heading}**\n\n${description}` : `**${heading}**`;
   }
 
   private embed(embed: DiscordEmbed): DiscordInteractionResponse {

--- a/src/api/versions/v1/services/discord-command-service.ts
+++ b/src/api/versions/v1/services/discord-command-service.ts
@@ -8,6 +8,7 @@ import {
 } from "../enums/notification-channel-enum.ts";
 import { EMBED_COLORS } from "../constants/discord-command-constants.ts";
 import { ENV_DISCORD_ALLOWED_ROLE_NAMES } from "../constants/environment-constants.ts";
+import { ServerError } from "../models/server-error.ts";
 import {
   DiscordCommandOptionType,
 } from "../enums/discord-command-option-enum.ts";
@@ -148,7 +149,7 @@ export class DiscordCommandService {
         }
         try {
           await this.serverMessagesService.create({ title, content });
-          return this.successResponse("News created", undefined, [
+          return this.embedResponse("News created", undefined, [
             {
               name: "Title",
               value: this.truncate(title, 1024),
@@ -181,7 +182,7 @@ export class DiscordCommandService {
         }
         try {
           await this.serverMessagesService.update({ id, title, content });
-          return this.successResponse(
+          return this.embedResponse(
             "News updated",
             `Updated **#${id}**`,
             [
@@ -201,6 +202,48 @@ export class DiscordCommandService {
           console.error("discord news update failed:", e);
           return this.errorResponse(
             "Update news failed",
+            DiscordCommandService.GENERIC_ERROR_MESSAGE,
+          );
+        }
+      }
+
+      case "view": {
+        const id = Number(values.get("id"));
+        if (!Number.isInteger(id) || id <= 0) {
+          return this.errorResponse(
+            "View news",
+            "A valid news ID is required.",
+          );
+        }
+        try {
+          const message = await this.serverMessagesService.get(id);
+          return this.embedResponse(`News #${message.id}`, undefined, [
+            {
+              name: "Title",
+              value: this.truncate(message.title, 1024),
+              inline: false,
+            },
+            {
+              name: "Content",
+              value: this.truncate(message.content, 1024),
+              inline: false,
+            },
+            {
+              name: "Updated",
+              value: this.formatTimestamp(message.updatedAt),
+              inline: true,
+            },
+          ]);
+        } catch (e) {
+          if (e instanceof ServerError && e.getStatusCode() === 404) {
+            return this.errorResponse(
+              "View news",
+              `News **#${id}** not found.`,
+            );
+          }
+          console.error("discord news view failed:", e);
+          return this.errorResponse(
+            "View news failed",
             DiscordCommandService.GENERIC_ERROR_MESSAGE,
           );
         }
@@ -235,14 +278,20 @@ export class DiscordCommandService {
           if (list.results.length === 0) {
             return this.infoResponse("News", "No news items yet.");
           }
-          return this.infoResponse(
-            `News (${list.results.length})`,
-            undefined,
-            list.results.map((item) => ({
-              name: this.truncate(`#${item.id} — ${item.title}`, 256),
-              value: this.contentSnippet(item.content),
-              inline: false,
-            })),
+          const items = list.results
+            .map(
+              (item) =>
+                `**#${item.id} — ${this.truncate(item.title, 256)}**\n` +
+                `Created ${this.formatTimestamp(item.createdAt)} · Updated ${
+                  this.formatTimestamp(item.updatedAt)
+                }`,
+            )
+            .join("\n\n");
+          return this.textResponse(
+            this.truncate(
+              `**News (${list.results.length})**\n\n${items}`,
+              2000,
+            ),
           );
         } catch (e) {
           console.error("discord news list failed:", e);
@@ -301,11 +350,36 @@ export class DiscordCommandService {
       : singleLine;
   }
 
+  private formatTimestamp(ms: number): string {
+    return new Date(ms).toISOString().replace(/\.\d{3}Z$/, "Z");
+  }
+
   private truncate(value: string, max: number): string {
     return value.length > max ? value.slice(0, max) : value;
   }
 
   private successResponse(
+    heading: string,
+    description?: string,
+  ): DiscordInteractionResponse {
+    return this.textResponse(this.withHeading(heading, description));
+  }
+
+  private infoResponse(
+    heading: string,
+    description?: string,
+  ): DiscordInteractionResponse {
+    return this.textResponse(this.withHeading(heading, description));
+  }
+
+  private errorResponse(
+    heading: string,
+    description?: string,
+  ): DiscordInteractionResponse {
+    return this.textResponse(this.withHeading(heading, description));
+  }
+
+  private embedResponse(
     heading: string,
     description?: string,
     fields?: DiscordEmbed["fields"],
@@ -317,30 +391,18 @@ export class DiscordCommandService {
     });
   }
 
-  private infoResponse(
-    heading: string,
-    description?: string,
-    fields?: DiscordEmbed["fields"],
-  ): DiscordInteractionResponse {
-    return this.embed({
-      description: this.withHeading(heading, description),
-      color: EMBED_COLORS.info,
-      fields,
-    });
-  }
-
-  private errorResponse(
-    heading: string,
-    description?: string,
-  ): DiscordInteractionResponse {
-    return this.embed({
-      description: this.withHeading(heading, description),
-      color: EMBED_COLORS.error,
-    });
-  }
-
   private withHeading(heading: string, description?: string): string {
     return description ? `**${heading}**\n\n${description}` : `**${heading}**`;
+  }
+
+  private textResponse(content: string): DiscordInteractionResponse {
+    return {
+      type: DiscordInteractionResponseType.ChannelMessageWithSource,
+      data: {
+        content,
+        flags: 64,
+      },
+    };
   }
 
   private embed(embed: DiscordEmbed): DiscordInteractionResponse {

--- a/src/api/versions/v1/services/server-messages-service.ts
+++ b/src/api/versions/v1/services/server-messages-service.ts
@@ -31,19 +31,35 @@ export class ServerMessagesService {
       .limit(limit + 1);
 
     const hasNextPage = messages.length > limit;
-    const results = messages.slice(0, limit).map((message) => ({
-      id: message.id,
-      title: message.title,
-      content: message.content,
-      createdAt: message.createdAt.getTime(),
-      updatedAt: message.updatedAt.getTime(),
-    }));
+    const results = messages.slice(0, limit).map((message) =>
+      this.toResponse(message),
+    );
 
     return {
       results,
       nextCursor: hasNextPage ? results[results.length - 1].id : undefined,
       hasMore: hasNextPage,
     };
+  }
+
+  public async get(id: number): Promise<ServerMessageResponse> {
+    const db = this.databaseService.get();
+
+    const [message] = await db
+      .select()
+      .from(serverMessagesTable)
+      .where(eq(serverMessagesTable.id, id))
+      .limit(1);
+
+    if (!message) {
+      throw new ServerError(
+        "MESSAGE_NOT_FOUND",
+        `Message with id ${id} does not exist`,
+        404,
+      );
+    }
+
+    return this.toResponse(message);
   }
 
   public async create(
@@ -95,13 +111,18 @@ export class ServerMessagesService {
       );
     }
 
-    const msg = updated[0];
+    return this.toResponse(updated[0]);
+  }
+
+  private toResponse(
+    message: typeof serverMessagesTable.$inferSelect,
+  ): ServerMessageResponse {
     return {
-      id: msg.id,
-      title: msg.title,
-      content: msg.content,
-      createdAt: msg.createdAt.getTime(),
-      updatedAt: msg.updatedAt.getTime(),
+      id: message.id,
+      title: message.title,
+      content: message.content,
+      createdAt: message.createdAt.getTime(),
+      updatedAt: message.updatedAt.getTime(),
     };
   }
 }

--- a/src/api/versions/v1/types/discord-interaction-response-type.ts
+++ b/src/api/versions/v1/types/discord-interaction-response-type.ts
@@ -3,5 +3,5 @@ import type { DiscordEmbed } from "./discord-embed-type.ts";
 
 export type DiscordInteractionResponse = {
   type: DiscordInteractionResponseType;
-  data?: { embeds?: DiscordEmbed[]; flags?: number };
+  data?: { content?: string; embeds?: DiscordEmbed[]; flags?: number };
 };


### PR DESCRIPTION
## Summary\n- Rename the "/alert" slash command to "/notification" (command, handler, strings, and option descriptions)\n- Replace "Flash news" wording with "Notification"\n- Remove titles from Discord response embeds; headings are now rendered as bold text in the embed description\n\n## Testing\n- `deno task check` passes\n- Registered commands via `deno task register-discord-commands` (2 global commands)