### PR TITLE
Ban Discord players by display name

### DIFF
--- a/src/api/versions/v1/constants/discord-command-constants.ts
+++ b/src/api/versions/v1/constants/discord-command-constants.ts
@@ -33,8 +33,8 @@ export const DISCORD_SLASH_COMMANDS: DiscordSlashCommandPayload[] = [
     description: "Temporarily or permanently ban a player",
     options: [
       {
-        name: "user-id",
-        description: "The user ID to ban",
+        name: "player-name",
+        description: "The player display name to ban",
         type: STRING,
         required: true,
       },

--- a/src/api/versions/v1/services/discord-command-service.ts
+++ b/src/api/versions/v1/services/discord-command-service.ts
@@ -132,15 +132,15 @@ export class DiscordCommandService {
     interaction: DiscordInteractionPayload,
   ): Promise<DiscordInteractionResponse> {
     const values = this.optionValues(interaction.data?.options);
-    const userId = String(values.get("user-id") ?? "").trim();
+    const playerName = String(values.get("player-name") ?? "").trim();
     const reason = String(values.get("reason") ?? "").trim();
     const durationValue = values.get("duration-value");
     const durationUnit = values.get("duration-unit");
 
-    if (!userId || !reason) {
+    if (!playerName || !reason) {
       return this.errorResponse(
         "Ban player",
-        "User ID and reason are required.",
+        "Player name and reason are required.",
       );
     }
 
@@ -151,21 +151,30 @@ export class DiscordCommandService {
       );
     }
 
-    const duration = durationValue === undefined
-      ? undefined
-      : {
-        value: Number(durationValue),
-        unit: String(durationUnit) as
-          | "minutes"
-          | "hours"
-          | "days"
-          | "weeks"
-          | "months"
-          | "years",
-      };
+    const duration = durationValue === undefined ? undefined : {
+      value: Number(durationValue),
+      unit: String(durationUnit) as
+        | "minutes"
+        | "hours"
+        | "days"
+        | "weeks"
+        | "months"
+        | "years",
+    };
+
+    const user = await this.userModerationService.getUserByDisplayName(
+      playerName,
+    );
+
+    if (!user) {
+      return this.errorResponse(
+        "Ban player failed",
+        `Player **${playerName}** was not found.`,
+      );
+    }
 
     const banRequest = BanUserRequestSchema.safeParse({
-      userId,
+      userId: user.id,
       reason,
       duration,
     });
@@ -181,7 +190,9 @@ export class DiscordCommandService {
       await this.userModerationService.banUser(banRequest.data);
       return this.successResponse(
         "Player banned",
-        `Banned **${userId}** ${this.describeDuration(duration)} for: ${reason}`,
+        `Banned **${user.displayName}** (${user.id}) ${
+          this.describeDuration(duration)
+        } for: ${reason}`,
       );
     } catch (e) {
       if (e instanceof ServerError) {

--- a/src/api/versions/v1/services/user-moderation-service.ts
+++ b/src/api/versions/v1/services/user-moderation-service.ts
@@ -43,6 +43,19 @@ export class UserModerationService {
     return !latestBan.expiresAt || latestBan.expiresAt > new Date();
   }
 
+  public async getUserByDisplayName(
+    displayName: string,
+  ): Promise<{ id: string; displayName: string } | null> {
+    const users = await this.databaseService
+      .get()
+      .select({ id: usersTable.id, displayName: usersTable.displayName })
+      .from(usersTable)
+      .where(eq(usersTable.displayName, displayName))
+      .limit(1);
+
+    return users[0] ?? null;
+  }
+
   public async banUser(body: BanUserRequest): Promise<void> {
     const { userId, reason, duration } = body;
     const db = this.databaseService.get();


### PR DESCRIPTION
### Motivation
- Allow moderators to ban players using their in-game display name instead of requiring the UUID to make the moderation workflow easier and less error-prone.

### Description
- Change the `/ban-player` Discord slash command option from `user-id` to `player-name` in `src/api/versions/v1/constants/discord-command-constants.ts`.
- Update the Discord command handler in `src/api/versions/v1/services/discord-command-service.ts` to validate `player-name`, resolve the corresponding user, and then create a ban using the resolved `user.id` while returning a response that shows both display name and ID.
- Add `getUserByDisplayName()` to `UserModerationService` in `src/api/versions/v1/services/user-moderation-service.ts` to look up a user by `displayName` before issuing the ban.

### Testing
- Ran `deno fmt` on the modified files (`src/api/versions/v1/constants/discord-command-constants.ts`, `src/api/versions/v1/services/discord-command-service.ts`, `src/api/versions/v1/services/user-moderation-service.ts`) which completed successfully. 
- Ran `deno task check` (type-check) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7522ac1e04832797a5865a502229ef)