### PR TITLE
Migrate Discord signature verification from discordeno to discord-interactions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "@hono/zod-openapi": "npm:@hono/zod-openapi@^1.5.1",
-    "discordeno": "npm:discordeno@18.0.1",
+    "discord-interactions": "npm:discord-interactions@^4.4.0",
     "@needle-di/core": "jsr:@needle-di/core@^1.1.3",
     "@scalar/hono-api-reference": "npm:@scalar/hono-api-reference@^0.11.12",
     "@simplewebauthn/server": "jsr:@simplewebauthn/server@^13.3.2",

--- a/deno.lock
+++ b/deno.lock
@@ -15,7 +15,7 @@
     "npm:@peculiar/x509@^1.14.3": "1.14.3",
     "npm:@scalar/hono-api-reference@~0.11.12": "0.11.12_hono@4.13.0",
     "npm:@types/pg@^8.20.4": "8.20.4",
-    "npm:discordeno@18.0.1": "18.0.1",
+    "npm:discord-interactions@^4.4.0": "4.4.0",
     "npm:drizzle-kit@*": "0.31.10",
     "npm:drizzle-kit@beta": "1.0.0-beta.22",
     "npm:drizzle-orm@*": "0.45.2_@types+pg@8.20.4_pg@8.22.0",
@@ -52,19 +52,6 @@
         "openapi3-ts",
         "zod"
       ]
-    },
-    "@deno/shim-deno-test@0.3.3": {
-      "integrity": "sha512-Ge0Tnl7zZY0VvEfgsyLhjid8DzI1d0La0dgm+3m0/A8gZXgp5xwlyIyue5e4SCUuVB/3AH/0lun9LcJhhTwmbg=="
-    },
-    "@deno/shim-deno@0.9.0": {
-      "integrity": "sha512-iP+qdI4Oy/Mw9yv40TqdjNKL+stpKDo8drki2cKisTXgZf+GoIdMhIuODxSypRyv6wxIuHNx7ZiKE3Sl3kAHuw==",
-      "dependencies": [
-        "@deno/shim-deno-test",
-        "which"
-      ]
-    },
-    "@deno/shim-timers@0.1.0": {
-      "integrity": "sha512-XFRnB5Rtbkd5RiYHwhugNK9gvDgYXmFTUOT5dmhWCKG7WnOWZggbJMnH1NcyYS3QgHvmaTOaHCyNFNSv57j3Dg=="
     },
     "@drizzle-team/brocli@0.10.2": {
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="
@@ -458,9 +445,6 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@fastify/busboy@2.1.1": {
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
-    },
     "@hexagon/base64@1.1.28": {
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="
     },
@@ -678,14 +662,8 @@
     "buffer-from@1.1.2": {
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "discordeno@18.0.1": {
-      "integrity": "sha512-d3D/HpC39YGInmxy2HK90kPpMMu2gYYsWuwtEEFPWpq2hlR9dvad4ihvLursPz5bj4Ob1NWOgPv3kz/bwMSIpw==",
-      "dependencies": [
-        "@deno/shim-deno",
-        "@deno/shim-timers",
-        "undici",
-        "ws"
-      ]
+    "discord-interactions@4.4.0": {
+      "integrity": "sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA=="
     },
     "drizzle-kit@0.31.10": {
       "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
@@ -843,9 +821,6 @@
     "hono@4.13.0": {
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="
     },
-    "isexe@2.0.0": {
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
     "jiti@2.7.0": {
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "bin": true
@@ -987,22 +962,6 @@
     "undici-types@8.3.0": {
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
-    "undici@5.29.0": {
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dependencies": [
-        "@fastify/busboy"
-      ]
-    },
-    "which@2.0.2": {
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": [
-        "isexe"
-      ],
-      "bin": true
-    },
-    "ws@8.21.2": {
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="
-    },
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
@@ -1022,7 +981,7 @@
       "npm:@hono/zod-openapi@^1.5.1",
       "npm:@scalar/hono-api-reference@~0.11.12",
       "npm:@types/pg@^8.20.4",
-      "npm:discordeno@18.0.1",
+      "npm:discord-interactions@^4.4.0",
       "npm:drizzle-kit@beta",
       "npm:drizzle-orm@beta",
       "npm:hono@^4.13.0",

--- a/src/api/middlewares/discord-signature-verification-middleware.ts
+++ b/src/api/middlewares/discord-signature-verification-middleware.ts
@@ -1,5 +1,5 @@
 import { createMiddleware } from "hono/factory";
-import { verifySignature } from "discordeno";
+import { verifyKey } from "discord-interactions";
 import { injectable } from "@needle-di/core";
 import { ServerError } from "../versions/v1/models/server-error.ts";
 import {
@@ -50,12 +50,12 @@ export class DiscordSignatureVerificationMiddleware {
       }
 
       const body = await context.req.text();
-      const { isValid } = verifySignature({
-        publicKey,
+      const isValid = await verifyKey(
+        body,
         signature,
         timestamp,
-        body,
-      });
+        publicKey,
+      );
       if (!isValid) {
         throw new ServerError(
           "DISCORD_SIGNATURE_INVALID",


### PR DESCRIPTION
Replaces the deprecated \discordeno\ dependency with \
pm:discord-interactions\ for verifying incoming Discord HTTP interaction signatures via \erifyKey\.

- Update \deno.json\ import from \discordeno@18.0.1\ → \discord-interactions@^4.4.0\
- Update \deno.lock\ accordingly
- Switch \discord-signature-verification-middleware.ts\ from \erifySignature({...})\ to the async \erifyKey(body, signature, timestamp, publicKey)\

All other Discord payloads/enums/commands were already defined locally, so the signature middleware was the only external-library consumer.